### PR TITLE
Removed `AbstractArray.centers` and all of its subclass implementations.

### DIFF
--- a/named_arrays/_core.py
+++ b/named_arrays/_core.py
@@ -1236,7 +1236,7 @@ def strata(a: AbstractArray) -> AbstractArray:
             strata.x,
             strata.y,
             ax=ax,
-        )
+        );
     """
     if isinstance(a, AbstractStratifiedRandomSpace):
         return a.strata

--- a/named_arrays/_core.py
+++ b/named_arrays/_core.py
@@ -1253,7 +1253,7 @@ class AbstractStratifiedRandomSpace(
 
     @property
     def explicit(self: Self) -> AbstractExplicitArray:
-        result = self.centers
+        result = self.strata
 
         step_size = self.step
 

--- a/named_arrays/_core.py
+++ b/named_arrays/_core.py
@@ -38,6 +38,7 @@ __all__ = [
     'AbstractArrayRange',
     'AbstractSpace',
     'AbstractLinearSpace',
+    'strata',
     'AbstractStratifiedRandomSpace',
     'AbstractLogarithmicSpace',
     'AbstractGeometricSpace',
@@ -359,14 +360,6 @@ class AbstractArray(
         """
         a = self.explicit
         return a.broadcast_to(a.shape)
-
-    @property
-    @abc.abstractmethod
-    def centers(self: Self) -> AbstractArray:
-        """
-        The central value for this array. Usually returns this array unless an instance of
-        :class:`named_arrays.AbstractStratifiedRandomSpace`
-        """
 
     @abc.abstractmethod
     def astype(
@@ -1051,10 +1044,6 @@ class AbstractUniformRandomSample(
             seed=self.seed,
         )
 
-    @property
-    def centers(self: Self) -> Self:
-        return self
-
 
 @dataclasses.dataclass
 class AbstractNormalRandomSample(
@@ -1079,10 +1068,6 @@ class AbstractNormalRandomSample(
             seed=self.seed,
         )
 
-    @property
-    def centers(self: Self) -> Self:
-        return self
-
 
 @dataclasses.dataclass
 class AbstractPoissonRandomSample(
@@ -1102,10 +1087,6 @@ class AbstractPoissonRandomSample(
             shape_random=self.shape_random,
             seed=self.seed,
         )
-
-    @property
-    def centers(self: Self) -> Self:
-        return self
 
 
 @dataclasses.dataclass(eq=False, repr=False)
@@ -1165,10 +1146,6 @@ class AbstractArrayRange(
         )
 
     @property
-    def centers(self: Self) -> Self:
-        return self
-
-    @property
     def num(self: Self) -> int:
         return np.ceil((self.stop - self.start) / self.step).astype(int)
 
@@ -1209,15 +1186,62 @@ class AbstractLinearSpace(
         )
 
     @property
-    def centers(self: Self) -> Self:
-        return self
-
-    @property
     def step(self: Self) -> AbstractArray:
         if self.endpoint:
             return self.range / (self.num - 1)
         else:
             return self.range / self.num
+
+
+def strata(a: AbstractArray) -> AbstractArray:
+    """
+    If ``a`` is an instance of :class:`AbstractStratifiedRandomSpace`,
+    return ``a.strata``, otherwise return ``a``
+
+    Parameters
+    ----------
+    a
+        An array to isolate the strata of.
+
+    Examples
+    --------
+
+    Make a scatterplot of a 2D stratified random array and the centers of
+    the strata.
+
+    .. jupyter-execute::
+
+        import matplotlib.pyplot as plt
+        import named_arrays as na
+
+        # Define a 2D stratified random array.
+        a = na.Cartesian2dVectorStratifiedRandomSpace(
+            start=-1,
+            stop=1,
+            axis=na.Cartesian2dVectorArray("x", "y"),
+            num=11,
+        )
+
+        # Isolate the strata of the array
+        strata = na.strata(a)
+
+        # Plot the array and the strata
+        fig, ax = plt.subplots()
+        na.plt.scatter(
+            a.x,
+            a.y,
+            ax=ax,
+        )
+        na.plt.scatter(
+            strata.x,
+            strata.y,
+            ax=ax,
+        )
+    """
+    if isinstance(a, AbstractStratifiedRandomSpace):
+        return a.strata
+    else:
+        return a
 
 
 @dataclasses.dataclass(eq=False, repr=False)
@@ -1243,7 +1267,7 @@ class AbstractStratifiedRandomSpace(
         return result + delta
 
     @property
-    def centers(self: Self) -> AbstractExplicitArray:
+    def strata(self: Self) -> AbstractExplicitArray:
         return na.linspace(
             start=self._attr_normalized("start"),
             stop=self._attr_normalized("stop"),
@@ -1278,10 +1302,6 @@ class AbstractLogarithmicSpace(
         )
 
     @property
-    def centers(self: Self) -> Self:
-        return self
-
-    @property
     def start(self: Self) -> ArrayLike:
         return self.base ** self.start_exponent
 
@@ -1311,7 +1331,3 @@ class AbstractGeometricSpace(
             num=self.num,
             endpoint=self.endpoint,
         )
-
-    @property
-    def centers(self: Self) -> Self:
-        return self

--- a/named_arrays/_functions/functions.py
+++ b/named_arrays/_functions/functions.py
@@ -60,13 +60,6 @@ class AbstractFunctionArray(
             outputs=self.outputs.value,
         )
 
-    @property
-    def centers(self) -> FunctionArray:
-        return self.type_explicit(
-            inputs=self.inputs.centers,
-            outputs=self.outputs.centers,
-        )
-
     def astype(
             self,
             dtype: str | np.dtype | type,

--- a/named_arrays/_matrices/matrices.py
+++ b/named_arrays/_matrices/matrices.py
@@ -386,9 +386,7 @@ class AbstractImplicitMatrixArray(
     AbstractMatrixArray,
     na.AbstractImplicitVectorArray
 ):
-    @property
-    def centers(self: Self) -> Self:
-        return self
+    pass
 
 
 @dataclasses.dataclass(eq=False, repr=False)

--- a/named_arrays/_scalars/scalars.py
+++ b/named_arrays/_scalars/scalars.py
@@ -855,10 +855,6 @@ class ScalarArray(
     def explicit(self: Self) -> Self:
         return self
 
-    @property
-    def centers(self: Self) -> Self:
-        return self
-
     def __setitem__(
             self: Self,
             item: dict[str, int | slice | AbstractScalarArray] | AbstractScalarArray,

--- a/named_arrays/_scalars/tests/test_scalars.py
+++ b/named_arrays/_scalars/tests/test_scalars.py
@@ -949,21 +949,23 @@ class AbstractTestAbstractScalarArray(
 
         @pytest.mark.parametrize(
             argnames="array_2",
-            argvalues=_scalar_arrays_2(),
+            argvalues=_scalar_arrays_2()[:8],
         )
         @pytest.mark.parametrize(
-            argnames="where",
+            argnames="where, alpha",
             argvalues=[
-                np._NoValue,
-                True,
-                na.linspace(0, 1, axis="x", num=_num_x) > 0.5,
-            ]
-        )
-        @pytest.mark.parametrize(
-            argnames="alpha",
-            argvalues=[
-                np._NoValue,
-                na.linspace(0, 1, axis="x", num=_num_x),
+                (
+                    np._NoValue,
+                    np._NoValue
+                ),
+                (
+                    True,
+                    na.linspace(0, 1, axis="x", num=_num_x),
+                ),
+                (
+                    na.linspace(0, 1, axis="x", num=_num_x) > 0.5,
+                    0.5,
+                )
             ]
         )
         class TestPltPlotLikeFunctions(
@@ -976,28 +978,26 @@ class AbstractTestAbstractScalarArray(
             argvalues=_scalar_arrays_2()[:8],
         )
         @pytest.mark.parametrize(
-            argnames="s",
+            argnames="s,c,where",
             argvalues=[
-                None,
-                5,
-            ]
-        )
-        @pytest.mark.parametrize(
-            argnames="c",
-            argvalues=[
-                None,
-                5,
-                na.ScalarArray(
-                    ndarray=np.array([.5, .5, .5, 1]),
-                    axes="rgba",
+                (
+                    None,
+                    None,
+                    None,
+                ),
+                (
+                    5,
+                    na.ScalarArray(
+                        ndarray=np.array([.5, .5, .5, 1]),
+                        axes="rgba",
+                    ),
+                    na.linspace(0, 1, axis="x", num=_num_x) > 0.5,
+                ),
+                (
+                    na.linspace(1, 2, axis="x", num=_num_x),
+                    5,
+                    True,
                 )
-            ]
-        )
-        @pytest.mark.parametrize(
-            argnames="where",
-            argvalues=[
-                True,
-                na.linspace(0, 1, axis="x", num=_num_x) > 0.5,
             ],
         )
         class TestPltScatter(
@@ -1243,6 +1243,7 @@ class TestScalarArrayCreation(
 
 
 class AbstractTestAbstractImplicitScalarArray(
+    AbstractTestAbstractScalarArray,
     tests.test_core.AbstractTestAbstractImplicitArray,
 ):
     pass

--- a/named_arrays/_scalars/uncertainties/uncertainties.py
+++ b/named_arrays/_scalars/uncertainties/uncertainties.py
@@ -569,10 +569,6 @@ class UncertainScalarArray(
     def explicit(self) -> Self:
         return self.copy_shallow()
 
-    @property
-    def centers(self) -> Self:
-        return self
-
     def __setitem__(
             self,
             item: dict[str, int | slice | na.AbstractScalar] | na.AbstractScalar,
@@ -705,10 +701,6 @@ class UniformUncertainScalarArray(
             distribution=na.explicit(self.distribution),
         )
 
-    @property
-    def centers(self) -> Self:
-        return self
-
 
 @dataclasses.dataclass(eq=False, repr=False)
 class NormalUncertainScalarArray(
@@ -736,10 +728,6 @@ class NormalUncertainScalarArray(
             nominal=na.explicit(self.nominal),
             distribution=na.explicit(self.distribution),
         )
-
-    @property
-    def centers(self) -> Self:
-        return self
 
 
 @dataclasses.dataclass(eq=False, repr=False)

--- a/named_arrays/_vectors/vectors.py
+++ b/named_arrays/_vectors/vectors.py
@@ -550,17 +550,6 @@ class AbstractExplicitVectorArray(
                 components_result[c] = components[c]
         return self.type_explicit.from_components(components_result)
 
-    @property
-    def centers(self: Self) -> AbstractExplicitVectorArray:
-        components = self.components
-        components_result = dict()
-        for c in components:
-            if isinstance(components[c], na.AbstractArray):
-                components_result[c] = components[c].centers
-            else:
-                components_result[c] = components[c]
-        return self.type_explicit.from_components(components_result)
-
     def __setitem__(
             self,
             item: dict[str, int | slice | AbstractScalarOrVectorArray] | AbstractScalarOrVectorArray,
@@ -829,8 +818,4 @@ class AbstractWcsVector(
     def explicit(self) -> na.AbstractExplicitArray:
         components = self._components_explicit | self._components_wcs
         return self.type_explicit.from_components(components)
-
-    @property
-    def centers(self: Self) -> Self:
-        return self
 

--- a/named_arrays/tests/test_core.py
+++ b/named_arrays/tests/test_core.py
@@ -1459,7 +1459,7 @@ class AbstractTestAbstractExplicitArrayCreation(
 
 
 class AbstractTestAbstractImplicitArray(
-    AbstractTestAbstractArray,
+    abc.ABC,
 ):
     def test_explicit(self, array: na.AbstractArray):
         result = array.explicit

--- a/named_arrays/tests/test_core.py
+++ b/named_arrays/tests/test_core.py
@@ -1096,6 +1096,10 @@ class AbstractTestAbstractArray(
             result = na.unit_normalized(array)
             assert isinstance(result, (u.UnitBase, na.AbstractArray))
 
+        def test_strata(self, array: na.AbstractArray):
+            result = na.strata(array)
+            assert result.type_abstract == array.type_abstract
+
         @pytest.mark.parametrize(
             argnames="slope",
             argvalues=[

--- a/named_arrays/tests/test_core.py
+++ b/named_arrays/tests/test_core.py
@@ -202,9 +202,6 @@ class AbstractTestAbstractArray(
         assert result.shape == array.shape
         assert isinstance(result, array.type_explicit)
 
-    def test_centers(self, array: na.AbstractArray):
-        assert isinstance(array.centers, na.AbstractArray)
-
     @abc.abstractmethod
     def test_astype(self, array: na.AbstractArray, dtype: type):
         pass


### PR DESCRIPTION
Added `named_arrays.strata()` function as a replacement.