### PR TITLE
Modified the behavior of `AbstractFunctionArray.__array_ufunc__()` to allow any instance of `AbstactArray` that is not a function to be an operand.

### DIFF
--- a/named_arrays/_functions/functions.py
+++ b/named_arrays/_functions/functions.py
@@ -626,10 +626,7 @@ class AbstractFunctionArray(
                     inputs_inputs.append(inp.inputs)
                     inputs_outputs.append(inp.outputs)
                 else:
-                    if not inp.shape:
-                        inputs_outputs.append(inp)
-                    else:
-                        return NotImplemented
+                    inputs_outputs.append(inp)
             else:
                 inputs_outputs.append(inp)
 


### PR DESCRIPTION
Previously in this case, the operand also had to have an empty shape, but this change relaxes that requirement.