### PR TITLE
Added `AbstractFunctionArray.integrate()`

### DIFF
--- a/named_arrays/_functions/functions.py
+++ b/named_arrays/_functions/functions.py
@@ -431,6 +431,92 @@ class AbstractFunctionArray(
             outputs=exp.outputs.cell_centers(axis, random=random),
         )
 
+    def integrate(
+        self,
+        axis: str | Sequence[str],
+        component: None | str = None,
+    ) -> FunctionArray:
+        """
+        Integrate the outputs over the given input ``axis`` or axes.
+
+        The differential measure is computed from the inputs via
+        :meth:`AbstractArray.volume_cell`:
+
+        * If ``component`` is :obj:`None`, the whole input is used as the
+          integration variable and ``len(axis)`` must match the dimensionality
+          of the inputs (one for a scalar, two for a
+          :class:`Cartesian2dVectorArray`, etc.).
+        * If ``component`` is a :class:`str`, that named sub-element of the
+          inputs (a scalar or a sub-vector) supplies the measure, and
+          ``len(axis)`` must match its dimensionality.
+
+        A vertex axis (where the inputs represent bin edges) is integrated with
+        a Riemann sum, while a center axis (where the inputs represent samples)
+        is integrated with the trapezoidal rule; mixing the two in a single
+        call is supported. The integrated axes are removed from the outputs and
+        collapsed in the inputs by averaging.
+
+        Parameters
+        ----------
+        axis
+            The logical axis or axes to integrate over.
+        component
+            The named input sub-element supplying the integration variable.
+            If :obj:`None`, the whole input is used.
+
+        Examples
+        --------
+
+        Integrate a constant function over a 1D domain.
+
+        .. jupyter-execute::
+
+            import numpy as np
+            import astropy.units as u
+            import named_arrays as na
+
+            f = na.FunctionArray(
+                inputs=na.ScalarLinearSpace(0, 2, axis="x", num=101) * u.nm,
+                outputs=na.ScalarArray(np.full(101, 3.0), axes=("x",)) * u.ph,
+            )
+
+            f.integrate("x")
+        """
+
+        self = self.explicit
+
+        if isinstance(axis, str):
+            axis = (axis,)
+        axis = tuple(axis)
+
+        if not set(axis).issubset(self.axes):
+            raise ValueError(f"axes {set(axis) - set(self.axes)} not in {self.axes}")
+
+        axes_vertex = self.axes_vertex
+        inputs = self.inputs
+        outputs = self.outputs
+
+        # convert outputs to cell centers along the center axes
+        # (corner-averaging across all center axes is the multi-D trapezoidal rule);
+        # vertex axes are already at cell centers relative to their input edges.
+        axes_center = tuple(ax for ax in axis if ax not in axes_vertex)
+        if axes_center:
+            outputs = outputs.cell_centers(axes_center)
+
+        # compute the joint cell measure from the selected component.
+        if component is None:
+            measure = inputs.volume_cell(axis)
+        else:
+            measure = inputs.components[component].volume_cell(axis)
+
+        outputs = (outputs * measure).sum(axis)
+        inputs = inputs.mean(axis)
+
+        return self.replace(
+            inputs=inputs,
+            outputs=outputs,
+        )
+
     def to_string_array(
         self,
         format_value: str = "%.2f",

--- a/named_arrays/_functions/tests/test_integrate.py
+++ b/named_arrays/_functions/tests/test_integrate.py
@@ -42,7 +42,7 @@ def test_integrate_constant_center(num: int):
     # constant integrand 3 over [0, 2] -> 3 * 2 = 6, exact.
     f = na.FunctionArray(
         inputs=na.ScalarLinearSpace(0, 2, axis="x", num=num) * u.nm,
-        outputs=na.ScalarArray(np.full(num, 3.0), axes=("x",)) * u.ph,
+        outputs=na.ScalarArray.full(dict(x=num), 3.0) * u.ph,
     )
     result = f.integrate("x")
     assert "x" not in result.outputs.shape
@@ -64,7 +64,7 @@ def test_integrate_constant_vertex():
     # constant integrand 3 over edges spanning [0, 2] -> 6, exact.
     f = na.FunctionArray(
         inputs=na.ScalarLinearSpace(0, 2, axis="x", num=11) * u.nm,
-        outputs=na.ScalarArray(np.full(10, 3.0), axes=("x",)) * u.ph,
+        outputs=na.ScalarArray.full(dict(x=10), 3.0) * u.ph,
     )
     result = f.integrate("x")
     assert "x" not in result.outputs.shape
@@ -80,7 +80,7 @@ def test_integrate_vector_center():
             axis=na.Cartesian2dVectorArray("x", "y"),
             num=na.Cartesian2dVectorArray(51, 41),
         ),
-        outputs=na.ScalarArray(np.full((51, 41), 3.0), axes=("x", "y")),
+        outputs=na.ScalarArray.full(dict(x=51, y=41), 3.0),
     )
     result = f.integrate(("x", "y"))
     assert not result.outputs.shape
@@ -96,7 +96,7 @@ def test_integrate_vector_vertex():
             axis=na.Cartesian2dVectorArray("x", "y"),
             num=na.Cartesian2dVectorArray(51, 41),
         ),
-        outputs=na.ScalarArray(np.full((50, 40), 3.0), axes=("x", "y")),
+        outputs=na.ScalarArray.full(dict(x=50, y=40), 3.0),
     )
     result = f.integrate(("x", "y"))
     assert not result.outputs.shape
@@ -119,7 +119,7 @@ def test_integrate_curved_grid():
     ).broadcasted.explicit
     f = na.FunctionArray(
         inputs=rotated,
-        outputs=na.ScalarArray(np.full((51, 51), 3.0), axes=("x", "y")),
+        outputs=na.ScalarArray.full(dict(x=51, y=51), 3.0),
     )
     # cells may be signed depending on traversal direction; compare magnitude.
     assert np.isclose(abs(float(f.integrate(("x", "y")).outputs.ndarray)), 12.0)
@@ -135,7 +135,7 @@ def test_integrate_component_str():
             axis=na.Cartesian2dVectorArray("x", "y"),
             num=na.Cartesian2dVectorArray(101, 51),
         ),
-        outputs=na.ScalarArray(np.full((101, 51), 3.0), axes=("x", "y")),
+        outputs=na.ScalarArray.full(dict(x=101, y=51), 3.0),
     )
     result = f.integrate("x", component="x")
     assert "x" not in result.outputs.shape
@@ -154,7 +154,7 @@ def test_integrate_mixed_axes():
             axis=na.Cartesian2dVectorArray("x", "y"),
             num=na.Cartesian2dVectorArray(11, 11),
         ),
-        outputs=na.ScalarArray(np.full((10, 11), 3.0), axes=("x", "y")),
+        outputs=na.ScalarArray.full(dict(x=10, y=11), 3.0),
     )
     result = f.integrate(("x", "y"))
     assert not result.outputs.shape

--- a/named_arrays/_functions/tests/test_integrate.py
+++ b/named_arrays/_functions/tests/test_integrate.py
@@ -1,0 +1,184 @@
+import pytest
+import numpy as np
+import astropy.units as u
+import named_arrays as na
+
+from . import test_functions
+from . import test_functions_vertices
+
+__all__ = []
+
+
+# All FunctionArray fixture sources -- center, vertex, and polynomial-fit --
+# combined so the shape-contract test exercises every family in one place.
+_fixtures = (
+    test_functions._function_arrays()
+    + test_functions._polynomial_function_arrays()
+    + test_functions_vertices._function_arrays()
+)
+
+
+@pytest.mark.parametrize("array", _fixtures)
+def test_integrate_shape_contract(array: na.AbstractFunctionArray):
+    """``axis`` removed from outputs and inputs; remaining axes preserved."""
+    array = array.explicit
+    inputs = array.inputs
+
+    # default component=None integrates the whole input via volume_cell,
+    # so axis must cover every dim of the inputs.
+    axis = tuple(inputs.shape)
+
+    if not axis:
+        return
+
+    # volume_cell isn't implemented on every fixture (e.g. composite vectors);
+    # if it isn't, integrate is expected to surface that error.
+    try:
+        inputs.volume_cell(axis)
+    except (NotImplementedError, TypeError, ValueError):
+        with pytest.raises((NotImplementedError, TypeError, ValueError)):
+            array.integrate(axis)
+        return
+
+    result = array.integrate(axis)
+
+    assert isinstance(result, na.FunctionArray)
+    for ax in axis:
+        assert ax not in result.outputs.shape
+        assert ax not in result.inputs.shape
+    assert set(result.outputs.shape) == set(array.outputs.shape) - set(axis)
+
+
+@pytest.mark.parametrize("num", [11, 101])
+def test_integrate_constant_center(num: int):
+    # center axis (inputs are samples) -> trapezoidal rule.
+    # constant integrand 3 over [0, 2] -> 3 * 2 = 6, exact.
+    f = na.FunctionArray(
+        inputs=na.ScalarLinearSpace(0, 2, axis="x", num=num) * u.nm,
+        outputs=na.ScalarArray(np.full(num, 3.0), axes=("x",)) * u.ph,
+    )
+    result = f.integrate("x")
+    assert "x" not in result.outputs.shape
+    assert np.allclose(result.outputs, 6 * u.nm * u.ph)
+
+
+@pytest.mark.parametrize("num", [11, 101])
+def test_integrate_linear_center(num: int):
+    # the trapezoidal rule is exact for a linear integrand:
+    # int_0^2 x dx = 2.
+    x = na.ScalarLinearSpace(0, 2, axis="x", num=num) * u.nm
+    f = na.FunctionArray(inputs=x, outputs=x)
+    result = f.integrate("x")
+    assert np.allclose(result.outputs, 2 * u.nm ** 2)
+
+
+def test_integrate_constant_vertex():
+    # vertex axis (inputs are bin edges, length N+1) -> Riemann sum.
+    # constant integrand 3 over edges spanning [0, 2] -> 6, exact.
+    f = na.FunctionArray(
+        inputs=na.ScalarLinearSpace(0, 2, axis="x", num=11) * u.nm,
+        outputs=na.ScalarArray(np.full(10, 3.0), axes=("x",)) * u.ph,
+    )
+    result = f.integrate("x")
+    assert "x" not in result.outputs.shape
+    assert np.allclose(result.outputs, 6 * u.nm * u.ph)
+
+
+def test_integrate_vector_center():
+    # 2D center grid, constant integrand 3 over [0,2]^2 -> 12 (component=None).
+    f = na.FunctionArray(
+        inputs=na.Cartesian2dVectorLinearSpace(
+            start=0,
+            stop=2,
+            axis=na.Cartesian2dVectorArray("x", "y"),
+            num=na.Cartesian2dVectorArray(51, 41),
+        ),
+        outputs=na.ScalarArray(np.full((51, 41), 3.0), axes=("x", "y")),
+    )
+    result = f.integrate(("x", "y"))
+    assert not result.outputs.shape
+    assert np.allclose(result.outputs, 12.0)
+
+
+def test_integrate_vector_vertex():
+    # 2D vertex grid (edges 51x41, cells 50x40), constant 3 over [0,2]^2 -> 12.
+    f = na.FunctionArray(
+        inputs=na.Cartesian2dVectorLinearSpace(
+            start=0,
+            stop=2,
+            axis=na.Cartesian2dVectorArray("x", "y"),
+            num=na.Cartesian2dVectorArray(51, 41),
+        ),
+        outputs=na.ScalarArray(np.full((50, 40), 3.0), axes=("x", "y")),
+    )
+    result = f.integrate(("x", "y"))
+    assert not result.outputs.shape
+    assert np.allclose(result.outputs, 12.0)
+
+
+def test_integrate_curved_grid():
+    # volume_cell-based measure handles non-rectilinear grids correctly.
+    # A 2x2 square rotated 30 degrees still has area 4.
+    v = na.Cartesian2dVectorLinearSpace(
+        start=0,
+        stop=2,
+        axis=na.Cartesian2dVectorArray("x", "y"),
+        num=na.Cartesian2dVectorArray(51, 51),
+    ).explicit
+    theta = np.deg2rad(30)
+    rotated = na.Cartesian2dVectorArray(
+        x=v.x * np.cos(theta) - v.y * np.sin(theta),
+        y=v.x * np.sin(theta) + v.y * np.cos(theta),
+    ).broadcasted.explicit
+    f = na.FunctionArray(
+        inputs=rotated,
+        outputs=na.ScalarArray(np.full((51, 51), 3.0), axes=("x", "y")),
+    )
+    # cells may be signed depending on traversal direction; compare magnitude.
+    assert np.isclose(abs(float(f.integrate(("x", "y")).outputs.ndarray)), 12.0)
+
+
+def test_integrate_component_str():
+    # component='x' integrates only the x sub-coordinate of a vector input,
+    # keeping the other dimension.
+    f = na.FunctionArray(
+        inputs=na.Cartesian2dVectorLinearSpace(
+            start=0,
+            stop=2,
+            axis=na.Cartesian2dVectorArray("x", "y"),
+            num=na.Cartesian2dVectorArray(101, 51),
+        ),
+        outputs=na.ScalarArray(np.full((101, 51), 3.0), axes=("x", "y")),
+    )
+    result = f.integrate("x", component="x")
+    assert "x" not in result.outputs.shape
+    assert "y" in result.outputs.shape
+    assert isinstance(result.inputs, na.Cartesian2dVectorArray)
+    assert np.allclose(result.outputs, 6.0)
+
+
+def test_integrate_mixed_axes():
+    # mix vertex (x: inputs N+1=11, outputs N=10) and center (y: inputs N=11, outputs N=11)
+    # in one integrate call. Constant integrand 3 over [0,2]^2 -> 12.
+    f = na.FunctionArray(
+        inputs=na.Cartesian2dVectorLinearSpace(
+            start=0,
+            stop=2,
+            axis=na.Cartesian2dVectorArray("x", "y"),
+            num=na.Cartesian2dVectorArray(11, 11),
+        ),
+        outputs=na.ScalarArray(np.full((10, 11), 3.0), axes=("x", "y")),
+    )
+    result = f.integrate(("x", "y"))
+    assert not result.outputs.shape
+    assert np.isclose(float(result.outputs.ndarray), 12.0)
+
+
+def test_integrate_invalid():
+    f_sca = na.FunctionArray(
+        inputs=na.ScalarLinearSpace(0, 1, axis="y", num=5),
+        outputs=na.ScalarArray(np.ones(5), axes=("y",)),
+    )
+
+    with pytest.raises(ValueError, match="not in"):
+        f_sca.integrate("z")

--- a/named_arrays/_functions/tests/test_integrate.py
+++ b/named_arrays/_functions/tests/test_integrate.py
@@ -22,23 +22,10 @@ _fixtures = (
 def test_integrate_shape_contract(array: na.AbstractFunctionArray):
     """``axis`` removed from outputs and inputs; remaining axes preserved."""
     array = array.explicit
-    inputs = array.inputs
 
     # default component=None integrates the whole input via volume_cell,
     # so axis must cover every dim of the inputs.
-    axis = tuple(inputs.shape)
-
-    if not axis:
-        return
-
-    # volume_cell isn't implemented on every fixture (e.g. composite vectors);
-    # if it isn't, integrate is expected to surface that error.
-    try:
-        inputs.volume_cell(axis)
-    except (NotImplementedError, TypeError, ValueError):
-        with pytest.raises((NotImplementedError, TypeError, ValueError)):
-            array.integrate(axis)
-        return
+    axis = tuple(array.inputs.shape)
 
     result = array.integrate(axis)
 


### PR DESCRIPTION
Integrates the outputs of a `FunctionArray` over the given input axis or axes, returning a `FunctionArray` with those axes collapsed.

## Behavior

The differential measure is computed from the inputs via `AbstractArray.volume_cell`. Combined with cell-center averaging of the outputs along center axes, this yields:

| axis type | rule | how |
|---|---|---|
| vertex (inputs are bin edges, length N+1) | Riemann sum | `(outputs * volume_cell).sum(axis)` |
| center (inputs are samples, length N) | trapezoidal | `(outputs.cell_centers(axis) * volume_cell).sum(axis)` |

Mixing vertex and center axes in a single call is supported. Because the measure goes through `volume_cell`, integrals over multi-dimensional vector inputs (e.g. `Cartesian2dVectorArray`) are correct on non-rectilinear / curved grids — not just axis-aligned ones.

## Signature

```python
def integrate(
    self,
    axis: str | Sequence[str],
    component: None | str = None,
) -> FunctionArray
```

- `component=None` (default): the whole input supplies the measure; `len(axis)` must match the input's dimensionality.
- `component=str`: that named sub-element (a scalar like `wavelength` or a sub-vector like `position`) supplies the measure; `len(axis)` matches its dimensionality.

## Examples

```python
import numpy as np, astropy.units as u, named_arrays as na

# 1D scalar integral, center axis
f = na.FunctionArray(
    inputs=na.ScalarLinearSpace(0, 2, axis="x", num=101) * u.nm,
    outputs=na.ScalarArray(np.full(101, 3.0), axes=("x",)) * u.ph,
)
f.integrate("x")                       # -> 6 nm ph

# 2D area integral over a vector input
v = na.Cartesian2dVectorLinearSpace(
    0, 2, axis=na.Cartesian2dVectorArray("x", "y"),
    num=na.Cartesian2dVectorArray(51, 41),
)
g = na.FunctionArray(v, na.ScalarArray(np.full((51, 41), 3.0), axes=("x", "y")))
g.integrate(("x", "y"))                # -> 12 (curved-grid-correct via volume_cell)

# integrate just one sub-coordinate, keep others
g.integrate("x", component="x")        # keeps y
```

## Tests

New `named_arrays/_functions/tests/test_integrate.py` (29 tests, all passing):

- Shape-contract test parametrized over the union of the center, polynomial-fit, and vertex fixture sources from `test_functions.py` / `test_functions_vertices.py`.
- Known-value tests covering: constant integrand on center / vertex axes (scalar and vector inputs); linear integrand on center axis (trapezoidal exactness); 30° rotated 2D grid (verifies curved-grid correctness via `volume_cell`); single-component extraction; mixed vertex+center axes; unknown-axis error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
