### PR TITLE
Add ScalarArray.full() classmethod

### DIFF
--- a/named_arrays/_scalars/scalars.py
+++ b/named_arrays/_scalars/scalars.py
@@ -993,6 +993,34 @@ class ScalarArray(
             axes=tuple(shape.keys()),
         )
 
+    @classmethod
+    def full(
+        cls: Type[Self],
+        shape: dict[str, int],
+        fill_value: float | u.Quantity,
+        dtype: None | Type | np.dtype = None,
+    ) -> Self:
+        """
+        Create a new array filled with `fill_value`.
+
+        Parameters
+        ----------
+        shape
+            shape of the new array
+        fill_value
+            value with which to fill the new array
+        dtype
+            data type of the new array
+
+        Returns
+        -------
+            A new array of the specified shape filled with `fill_value`
+        """
+        return cls(
+            ndarray=np.full(shape=tuple(shape.values()), fill_value=fill_value, dtype=dtype),
+            axes=tuple(shape.keys()),
+        )
+
     @property
     def shape(self: Self) -> dict[str, int]:
         try:

--- a/named_arrays/_scalars/tests/test_scalars.py
+++ b/named_arrays/_scalars/tests/test_scalars.py
@@ -1499,6 +1499,19 @@ class TestScalarArrayCreation(
             assert np.all(result == 1)
             assert result.dtype == dtype
 
+        @pytest.mark.parametrize("fill_value", [0, 1, 3.14])
+        def test_full(
+                self,
+                type_array: type[na.AbstractArray],
+                shape: dict[str, int],
+                dtype: None | type | np.dtype | str,
+                fill_value: float,
+        ):
+            result = type_array.full(shape, fill_value=fill_value, dtype=dtype)
+            assert result.shape == shape
+            assert np.all(result == np.array(fill_value).astype(dtype))
+            assert result.dtype == dtype
+
 
 class AbstractTestAbstractImplicitScalarArray(
     AbstractTestAbstractScalarArray,


### PR DESCRIPTION
## Summary
- Added `ScalarArray.full(shape, fill_value, dtype=None)`, a classmethod that creates a new array filled with `fill_value`, in the same spirit as `ScalarArray.ones()` / `zeros()` / `empty()`.
- Added a corresponding `test_full` case parametrized over the same `shape`/`dtype` combinations as the existing creation tests, plus a few representative `fill_value`s.

## Test plan
- [x] `pytest named_arrays/_scalars/tests/test_scalars.py -k test_full` (18 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)