### PR TITLE
Allow logical scalar components in `AbstractVectorArray.__getitem__()`

### DIFF
--- a/named_arrays/_vectors/vectors.py
+++ b/named_arrays/_vectors/vectors.py
@@ -330,8 +330,17 @@ class AbstractVectorArray(
 
         components_result = dict()
         for c in components:
+            component = components[c]
             if isinstance(item, dict):
-                components_result[c] = na.as_named_array(components[c])[{ax: item[ax].components[c] for ax in item}]
+                if na.named_array_like(component):
+                    components_result[c] = na.as_named_array(components[c])[{ax: item[ax].components[c] for ax in item}]
+                elif not na.shape(component):
+                    components_result[c] = component
+                else:
+                    raise ValueError(
+                        f"If component {c=} is not an instance of AbstractArray,"
+                        f"it must be a logical scalar, instead got {na.shape(component)=}."
+                    )
             else:
                 components_result[c] = components[c][na.as_named_array(item.components[c])]
 


### PR DESCRIPTION
When indexing a vector array with a `dict` of arrays in `AbstractVectorArray.__getitem__()`, each component was unconditionally treated as named-array-like. This change handles components that are plain logical scalars:

- Named-array-like components are indexed as before.
- Logical scalar components (no shape) are passed through unchanged.
- Shaped components that are not named-array-like now raise an informative `ValueError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)