### PR TITLE
Add `na.Indexable`, a mixin for composite named-array objects

### DIFF
--- a/named_arrays/__init__.py
+++ b/named_arrays/__init__.py
@@ -76,6 +76,9 @@ from ._core import (
     AbstractNormalRandomSample,
     AbstractPoissonRandomSample,
 )
+from ._mixins import (
+    Indexable,
+)
 from ._scalars.scalars import (
     ScalarStartT,
     ScalarStopT,
@@ -474,6 +477,7 @@ __all__ = [
     "AbstractUniformRandomSample",
     "AbstractNormalRandomSample",
     "AbstractPoissonRandomSample",
+    "Indexable",
     "ScalarStartT",
     "ScalarStopT",
     "ScalarTypeError",

--- a/named_arrays/_mixins.py
+++ b/named_arrays/_mixins.py
@@ -1,0 +1,79 @@
+import abc
+import dataclasses
+import math
+from typing_extensions import Self
+import named_arrays as na
+
+__all__ = [
+    "Indexable",
+]
+
+
+@dataclasses.dataclass(eq=False)
+class Indexable(
+    abc.ABC,
+):
+    """
+    A mixin for immutable composite objects whose fields are named arrays.
+
+    This class provides a :attr:`shape` and a named ``__getitem__`` by
+    delegating to :func:`named_arrays.shape` and :func:`named_arrays.getitem`,
+    both of which recurse into the :mod:`dataclasses` fields of the object.
+    A subclass is therefore expected to be an (immutable) :mod:`dataclasses`
+    instance whose fields are named arrays, or nested structures thereof.
+
+    The :attr:`ndim`, :attr:`size`, and :attr:`axes` properties are derived
+    from :attr:`shape`, so a subclass usually needs to define only its fields.
+
+    .. warning::
+
+        Do not combine this mixin with :class:`named_arrays.AbstractArray` or
+        any other object recognized by :func:`named_arrays.named_array_like`.
+        For such objects :func:`named_arrays.shape` and
+        :func:`named_arrays.getitem` index the object directly, which would
+        recurse back into the properties defined here and never terminate.
+    """
+
+    @property
+    def shape(self: Self) -> dict[str, int]:
+        """
+        The broadcasted shape of every array-like field of this object.
+        """
+        return na.shape(self)
+
+    @property
+    def ndim(self: Self) -> int:
+        """
+        The number of dimensions of this object, ``len(self.shape)``.
+        """
+        return len(self.shape)
+
+    @property
+    def size(self: Self) -> int:
+        """
+        The total number of elements in this object, the product of the
+        values of :attr:`shape`.
+        """
+        return math.prod(self.shape.values())
+
+    @property
+    def axes(self: Self) -> tuple[str, ...]:
+        """
+        The names of the axes of this object, ``tuple(self.shape)``.
+        """
+        return tuple(self.shape)
+
+    def __getitem__(
+        self: Self,
+        item: dict[str, int | slice | na.AbstractArray] | na.AbstractArray,
+    ) -> Self:
+        """
+        Index every array-like field of this object by ``item``.
+
+        Parameters
+        ----------
+        item
+            The named index to apply to each array-like field, for example a
+            :class:`dict` mapping axis names to index arrays.
+        """
+        return na.getitem(self, item)

--- a/named_arrays/tests/test_mixins.py
+++ b/named_arrays/tests/test_mixins.py
@@ -1,0 +1,92 @@
+import abc
+import dataclasses
+import math
+import numpy as np
+import pytest
+import named_arrays as na
+
+
+class AbstractTestIndexable(
+    abc.ABC,
+):
+    """
+    Base test class for subclasses of :class:`named_arrays.Indexable`.
+
+    Concrete test classes inherit from this and parametrize an ``indexable``
+    argument with instances of the :class:`named_arrays.Indexable` subclass
+    under test. Every test derives what it needs from the instance itself
+    (shape, axes, ...), so no further parameters are required. The
+    ``AbstractTest`` name prefix keeps pytest from collecting this base class
+    directly.
+    """
+
+    def test_shape(self, indexable: na.Indexable):
+        shape = indexable.shape
+        assert isinstance(shape, dict)
+        for axis in shape:
+            assert isinstance(axis, str)
+            assert isinstance(shape[axis], int)
+        # the property must agree with the top-level ``na.shape``
+        assert shape == na.shape(indexable)
+
+    def test_ndim(self, indexable: na.Indexable):
+        assert indexable.ndim == len(indexable.shape)
+
+    def test_size(self, indexable: na.Indexable):
+        size = indexable.size
+        assert isinstance(size, int)
+        assert size == math.prod(indexable.shape.values())
+
+    def test_axes(self, indexable: na.Indexable):
+        axes = indexable.axes
+        assert isinstance(axes, tuple)
+        assert set(axes) == set(indexable.shape)
+        for axis in axes:
+            assert isinstance(axis, str)
+
+    def test_getitem(self, indexable: na.Indexable):
+        shape = indexable.shape
+
+        if shape:
+            # index one axis by an identity range along itself, which should
+            # round-trip the object while preserving its shape
+            axis = next(iter(shape))
+            item = {axis: na.ScalarArray(np.arange(shape[axis]), axes=axis)}
+        else:
+            # a zero-dimensional object can only be indexed by an empty dict
+            item = {}
+
+        result = indexable[item]
+
+        # a new instance of the same type, original left unchanged (immutable)
+        assert type(result) is type(indexable)
+        assert result is not indexable
+        assert result.shape == shape
+        assert indexable.shape == shape
+
+
+@dataclasses.dataclass(eq=False)
+class _Point(na.Indexable):
+    """A minimal composite type used to validate ``AbstractTestIndexable``."""
+    x: na.AbstractScalar
+    y: na.AbstractScalar
+    label: str = "point"
+
+
+@pytest.mark.parametrize(
+    argnames="indexable",
+    argvalues=[
+        _Point(
+            x=na.arange(0, 5, axis="t"),
+            y=na.arange(0, 3, axis="w"),
+        ),
+        _Point(
+            x=na.ScalarArray(2),
+            y=na.ScalarArray(3),
+        ),
+    ],
+)
+class TestIndexable(
+    AbstractTestIndexable,
+):
+    pass


### PR DESCRIPTION
Adds `na.Indexable`, a dataclass mixin in the new `named_arrays/_mixins.py`, for immutable composite objects whose fields are named arrays.

## What it provides

By delegating to the recently-added recursive `na.shape()` and `na.getitem()`, a subclass gets a full named-array-like surface for free, usually only needing to declare its fields:

- `shape` -> `na.shape(self)` (broadcast of every array-like field)
- `__getitem__` -> `na.getitem(self, item)` (indexes each field, rebuilds via `dataclasses.replace`, immutable-safe)
- `ndim`, `size`, `axes` derived from `shape`

This generalizes the hand-rolled `broadcast_shapes(na.shape(x), na.shape(y), ...)` `.shape` properties found in downstream packages.

## Constraint (documented in the docstring)

Must not be combined with `na.AbstractArray` or any `named_array_like` type: for those, `na.shape`/`na.getitem` index the object directly, which would recurse back into these properties indefinitely. The mixin is intended for non-array composite dataclasses.

## Tests

- `AbstractTestIndexable` — a reusable base test class; the `AbstractTest` prefix keeps pytest from collecting it directly, and the `__getitem__` test derives a valid index from the instance's own shape so subclasses only supply the instance.
- `TestIndexable` — parametrizes the base over a multi-axis and a zero-dimensional instance (10 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)