### PR TITLE
Ignore missing axes when indexing a `FunctionArray` by a dict

### DIFF
--- a/named_arrays/_functions/functions.py
+++ b/named_arrays/_functions/functions.py
@@ -563,8 +563,11 @@ class AbstractFunctionArray(
 
         elif isinstance(item, dict):
 
-            if not set(item).issubset(array.axes): # pragma: no cover
-                raise ValueError(f"item contains axes {set(item) - set(array.axes)} that does not exist in {set(array.axes)}")
+            # ignore axes that are not present in this function array, so that
+            # indexing is consistent with ``ScalarArray`` and composes with
+            # ``na.getitem`` over heterogeneous structures (e.g. a function
+            # array that lacks the axis being selected is left untouched)
+            item = {ax: item[ax] for ax in item if ax in array.axes}
 
             item_inputs = dict()
             item_outputs = dict()

--- a/named_arrays/_functions/tests/test_functions.py
+++ b/named_arrays/_functions/tests/test_functions.py
@@ -198,6 +198,7 @@ class AbstractTestAbstractFunctionArray(
         argnames='item',
         argvalues=[
             dict(y=0),
+            dict(z=0),  # an axis not present in the function array: indexing is a no-op
             dict(y=slice(0, 1)),
             dict(y=na.ScalarArrayRange(0, 2, axis='y')),
             dict(


### PR DESCRIPTION
`FunctionArray.__getitem__` raised a `ValueError` when the index `dict` contained an axis the function array does not have. This changes it to filter those axes out instead, matching what `ScalarArray` already does (`_scalars/scalars.py`), so indexing by a missing axis is a no-op rather than an error.

## Motivation

This makes `na.getitem` robust over heterogeneous structures: a `FunctionArray` field that lacks the axis being selected is now left untouched instead of raising. It is the named-arrays-side counterpart to the per-leaf axis filtering done by `esis.optics.dataclass_select` (esis-mission/esis#61) and composes with the `na.Indexable` mixin (sun-data/named-arrays#180).

## Impact analysis

`array.axes` is the union of input and output axes, and `axes_center`/`axes_vertex` partition it. The filter only removes axes absent from **both** inputs and outputs, so it never touches a center or vertex axis: the existing center/vertex bookkeeping is gated on axis-membership tests that a missing axis already fails. The empty-filter case (index only a missing axis) reduces to `inputs[{}]`/`outputs[{}]`, a verified no-op for both cell-centered and vertex function arrays. The only behavioral change is the loss of FunctionArray-specific typo detection, which makes it consistent with `ScalarArray` (and the old guard carried `# pragma: no cover`, so it was untested).

## Tests

Extends the existing parametrized `test__getitem__` with a `dict(z=0)` (missing-axis) case. This item would have raised before the change, so it directly guards the new behavior. `pytest -k getitem` passes (135).

🤖 Generated with [Claude Code](https://claude.com/claude-code)