### PR TITLE
Make `na.nominal()` recurse into nested structures

### DIFF
--- a/named_arrays/_scalars/uncertainties/tests/test_uncertainties.py
+++ b/named_arrays/_scalars/uncertainties/tests/test_uncertainties.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Sequence, Callable
 import numpy as np
 import pytest
@@ -7,6 +8,7 @@ import named_arrays.tests.test_core
 import named_arrays._scalars.tests.test_scalars
 
 __all__ = [
+    'TestNominalRecursive',
     'AbstractTestAbstractUncertainScalarArray',
     'TestUncertainScalarArray',
     'TestUncertainScalarArrayCreation',
@@ -67,6 +69,58 @@ def _uncertain_scalar_arrays_2():
     ]
     arrays = arrays_exact + arrays_uncertain
     return arrays
+
+
+@dataclasses.dataclass(eq=False)
+class _NominalContainer:
+    """A composite dataclass used to exercise the recursion of ``na.nominal``."""
+    data: na.AbstractScalar
+    label: str = "data"
+    size: int = dataclasses.field(init=False, default=-1)
+
+
+class TestNominalRecursive:
+    """Tests for the recursion of :func:`named_arrays.nominal` into nested structures."""
+
+    def _uncertain(self) -> na.UncertainScalarArray:
+        return na.UniformUncertainScalarArray(5, 4, num_distribution=_num_distribution).explicit
+
+    def _expected(self):
+        # the nominal value is deterministic (only the distribution is random)
+        return self._uncertain().nominal
+
+    def test_nominal_scalar_passthrough(self):
+        assert na.nominal(7) == 7
+
+    def test_nominal_dict(self):
+        result = na.nominal({"a": self._uncertain(), "b": 2})
+        assert isinstance(result, dict)
+        assert np.all(result["a"] == self._expected())
+        assert result["b"] == 2
+
+    def test_nominal_list(self):
+        result = na.nominal([self._uncertain()])
+        assert isinstance(result, list)
+        assert np.all(result[0] == self._expected())
+
+    def test_nominal_tuple(self):
+        result = na.nominal((self._uncertain(), 7))
+        assert isinstance(result, tuple)
+        assert np.all(result[0] == self._expected())
+        assert result[1] == 7
+
+    def test_nominal_nested(self):
+        result = na.nominal({"a": [self._uncertain()]})
+        assert np.all(result["a"][0] == self._expected())
+
+    def test_nominal_dataclass(self):
+        result = na.nominal(_NominalContainer(data=self._uncertain()))
+        assert isinstance(result, _NominalContainer)
+        assert np.all(result.data == self._expected())
+        # non-array fields are passed through unchanged
+        assert result.label == "data"
+        # ``init=False`` fields are skipped by ``dataclasses.replace``
+        assert result.size == -1
 
 
 class AbstractTestAbstractUncertainScalarArray(

--- a/named_arrays/_scalars/uncertainties/uncertainties.py
+++ b/named_arrays/_scalars/uncertainties/uncertainties.py
@@ -73,8 +73,11 @@ def nominal(
 ) -> AnyT | NominalArrayT:
     """
     Isolate the `nominal` attribute of an uncertain array.
-    If `a` is a nested object, such a vector, this function is recursively
-    applied to all the attributes of the nested object.
+    If `a` is a nested object, such as a vector, or an arbitrarily-nested
+    structure (:class:`dict`, :class:`list`, :class:`tuple`, or
+    :mod:`dataclasses` instance), this function is recursively applied to all
+    the attributes/elements of the nested object, leaving non-array values
+    unchanged.
 
     Parameters
     ----------
@@ -111,12 +114,27 @@ def nominal(
 
         na.nominal(a)
     """
-    try:
-        return na._named_array_function(
-            func=nominal,
-            a=a,
-        )
-    except TypeError:
+    if na.named_array_like(a):
+        try:
+            return na._named_array_function(
+                func=nominal,
+                a=a,
+            )
+        except TypeError:
+            return a
+    elif isinstance(a, dict):
+        return {key: nominal(a[key]) for key in a}
+    elif isinstance(a, list):
+        return [nominal(a_i) for a_i in a]
+    elif isinstance(a, tuple):
+        return tuple(nominal(a_i) for a_i in a)
+    elif dataclasses.is_dataclass(a):
+        return dataclasses.replace(a, **{
+            field.name: nominal(getattr(a, field.name))
+            for field in dataclasses.fields(a)
+            if field.init
+        })
+    else:
         return a
 
 


### PR DESCRIPTION
Extends `na.nominal()` to recurse into arbitrarily-nested structures, mirroring `na.getitem()` and the recursive `na.shape()`.

## Behavior

- **named-array-like** (uncertain scalars, vectors, ...) — handled first via the existing dispatcher, so the prior behavior (including vector component recursion) is unchanged.
- **`dict` / `list` / `tuple` / dataclass** — `na.nominal()` is applied to every element/field, returning a structure of the same shape. Dataclass fields declared with `init=False` are skipped so `dataclasses.replace()` does not fail.
- **any other value** — returned unchanged.

Previously a container was returned untouched (its uncertain leaves were *not* reduced to their nominal values), so this fills a gap rather than changing behavior for any leaf/array caller.

## Tests

Adds a standalone `TestNominalRecursive` class covering each container type, nesting, the dataclass / `init=False` case, and scalar pass-through. All existing `nominal` tests still pass (74 nominal-related tests green); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)