### PR TITLE
Fix `weights_input` alignment in conservative regridding

### DIFF
--- a/named_arrays/_vectors/vector_named_array_functions.py
+++ b/named_arrays/_vectors/vector_named_array_functions.py
@@ -946,7 +946,7 @@ def regridding_weights(
     axis_output = tuple(tuple(shape_output).index(a) for a in axis_output)
 
     if weights_input is not None:
-        weights_input = weights_input.ndarray_aligned(shape_output)
+        weights_input = weights_input.ndarray_aligned(shape_input)
 
     result, _shape_input, _shape_output = regridding.weights(
         coordinates_input=coordinates_input,
@@ -1086,7 +1086,7 @@ def regridding_transpose_weights_conservative(
     axis_output = tuple(tuple(shape_output).index(a) for a in axis_output)
 
     if weights_input is not None:
-        weights_input = weights_input.ndarray_aligned(shape_output)
+        weights_input = weights_input.ndarray_aligned(shape_input)
 
     result, _, _ = regridding.transpose_weights_conservative(
         weights=weights,

--- a/named_arrays/tests/test_regridding.py
+++ b/named_arrays/tests/test_regridding.py
@@ -72,7 +72,8 @@ def test_regrid_multilinear_1d(
 
 
 @pytest.mark.parametrize(
-    argnames="coordinates_input, values_input, axis_input, coordinates_output, axis_output",
+    argnames="coordinates_input, values_input, axis_input, "
+    "coordinates_output, axis_output, weights_input",
     argvalues=[
         (
             na.Cartesian2dVectorArray(x, y),
@@ -83,6 +84,7 @@ def test_regrid_multilinear_1d(
                 y=1.2 * y + 0.01,
             ),
             None,
+            1,
         ),
         (
             na.Cartesian2dVectorArray(
@@ -96,6 +98,19 @@ def test_regrid_multilinear_1d(
                 y=1.2 * (y + 0.01 * z) + 0.001,
             ),
             ("x", "y"),
+            1,
+        ),
+        (
+            # distinct output axis names with a per-input-cell ``weights_input``
+            na.Cartesian2dVectorArray(x, y),
+            na.random.normal(0, 1, shape_random=shape_centers),
+            ("x", "y"),
+            na.Cartesian2dVectorArray(
+                x=1.1 * na.linspace(-1, 1, axis="x_new", num=shape_vertices["x"]) + 0.01,
+                y=1.2 * na.linspace(-1, 1, axis="y_new", num=shape_vertices["y"]) + 0.01,
+            ),
+            ("x_new", "y_new"),
+            na.random.uniform(0.5, 1.5, shape_random=shape_centers),
         ),
     ],
 )
@@ -105,6 +120,7 @@ def test_regrid_conservative_2d(
     values_input: np.ndarray,
     axis_input: None | int | tuple[int, ...],
     axis_output: None | int | tuple[int, ...],
+    weights_input: int | na.AbstractScalar,
 ):
     result = na.regridding.regrid(
         coordinates_input=coordinates_input,
@@ -145,6 +161,28 @@ def test_regrid_conservative_2d(
     assert np.issubdtype(result.dtype, float)
     assert result.shape == shape_result
     assert np.allclose(result.sum(), values_input.sum())
+
+    # a non-scalar ``weights_input`` is applied per *input* cell, so passing it
+    # to ``weights`` must be equivalent to folding it into the input values
+    # before regridding.  ``perturb=False`` keeps the two geometric weights
+    # identical so the results can be compared exactly.
+    kwargs_weights = dict(
+        coordinates_input=coordinates_input,
+        coordinates_output=coordinates_output,
+        axis_input=axis_input,
+        axis_output=axis_output,
+        method="conservative",
+        perturb=False,
+    )
+    result_weighted = na.regridding.regrid_from_weights(
+        *na.regridding.weights(weights_input=weights_input, **kwargs_weights),
+        values_input=values_input,
+    )
+    result_folded = na.regridding.regrid_from_weights(
+        *na.regridding.weights(**kwargs_weights),
+        values_input=values_input * weights_input,
+    )
+    assert np.allclose(result_weighted, result_folded)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`na.regridding.weights` (and `transpose_weights_conservative`) aligned the `weights_input` array to the **output** grid shape before passing it to the low-level `regridding` kernels. But those kernels broadcast `weights_input` to the **input** cell shape and apply it per input cell — matching the docstring ("Weights applied to the values of the input grid before resampling"):

- `regridding/_weights/_weights_conservative.py:53` → `np.broadcast_to(weights_input, shape_values_input)`
- `regridding/_weights/_weights_transposed/_weights_transposed.py:207` → `np.broadcast_to(weights_input, shape_input)`

The mismatch only surfaced when `weights_input` was **non-scalar** *and* the input/output axes had **different names**: aligning to `shape_output` raised `ValueError: axes is missing axes present in the input array` because the input axes were absent from the output shape. A scalar `weights_input` (the only case the tests previously exercised) broadcasts to any shape, hiding the bug.

## Change

- Align `weights_input` to `shape_input` in both `regridding_weights` and `regridding_transpose_weights_conservative`.
- Extend `test_regrid_conservative_2d` with a non-scalar `weights_input` over distinct output axes, asserting that passing `weights_input` is equivalent to folding it into the input values before regridding (`Σ overlapᵢⱼ·wᵢ·vᵢ`). Verified the new case fails without the fix (raises the `ValueError`) and passes with it.

## Notes

- `test_transpose_weights_conservative` is flaky on `main` independent of this change (random `perturb` resolving degenerate-grid ties differently across calls); not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)