### PR TITLE
Fix np.stack and np.concatenate for mixed named-array and plain inputs

### DIFF
--- a/named_arrays/_functions/tests/test_functions.py
+++ b/named_arrays/_functions/tests/test_functions.py
@@ -481,6 +481,32 @@ class AbstractTestAbstractFunctionArray(
             super().test_repeat(array, repeats, axis)
 
         @pytest.mark.parametrize("array_2", _function_arrays_2())
+        class TestStackLikeFunctions(
+            named_arrays.tests.test_core.AbstractTestAbstractArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            def test_stack(
+                    self,
+                    array: na.AbstractFunctionArray,
+                    array_2: None | float | u.Quantity | na.AbstractArray,
+                    axis: str,
+                    use_out: bool,
+            ):
+                # stacking a function with an array that is not a function
+                # is rejected since there is no way to promote the other
+                # array to a function
+                if not isinstance(array_2, na.AbstractFunctionArray):
+                    with pytest.raises(TypeError):
+                        np.stack([array, array_2], axis=axis)
+                    return
+
+                super().test_stack(
+                    array=array,
+                    array_2=array_2,
+                    axis=axis,
+                    use_out=use_out,
+                )
+
+        @pytest.mark.parametrize("array_2", _function_arrays_2())
         class TestAsArrayLikeFunctions(
             named_arrays.tests.test_core.AbstractTestAbstractArray.TestArrayFunctions.TestAsArrayLikeFunctions
         ):

--- a/named_arrays/_functions/tests/test_functions.py
+++ b/named_arrays/_functions/tests/test_functions.py
@@ -489,7 +489,6 @@ class AbstractTestAbstractFunctionArray(
                     array: na.AbstractFunctionArray,
                     array_2: None | float | u.Quantity | na.AbstractArray,
                     axis: str,
-                    use_out: bool,
             ):
                 # stacking a function with an array that is not a function
                 # is rejected since there is no way to promote the other
@@ -503,7 +502,6 @@ class AbstractTestAbstractFunctionArray(
                     array=array,
                     array_2=array_2,
                     axis=axis,
-                    use_out=use_out,
                 )
 
         @pytest.mark.parametrize("array_2", _function_arrays_2())

--- a/named_arrays/_matrices/cartesian/tests/test_matrices_cartesian_2d.py
+++ b/named_arrays/_matrices/cartesian/tests/test_matrices_cartesian_2d.py
@@ -204,6 +204,16 @@ class AbstractTestAbstractCartesian2dMatrixArray(
     ):
         pass
 
+    class TestArrayFunctions(
+        named_arrays._vectors.cartesian.tests.test_vectors_cartesian_2d
+        .AbstractTestAbstractCartesian2dVectorArray.TestArrayFunctions,
+    ):
+        @pytest.mark.parametrize('array_2', _cartesian_2d_matrices_2())
+        class TestStackLikeFunctions(
+            named_arrays.tests.test_core.AbstractTestAbstractArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
     @pytest.mark.parametrize(
         argnames='array_2',
         argvalues=_cartesian_2d_matrices_2() + [na.Cartesian2dVectorArray(1, 2)]

--- a/named_arrays/_scalars/tests/test_scalars.py
+++ b/named_arrays/_scalars/tests/test_scalars.py
@@ -679,6 +679,12 @@ class AbstractTestAbstractScalarArray(
     ):
 
         @pytest.mark.parametrize("array_2", _scalar_arrays_2())
+        class TestStackLikeFunctions(
+            AbstractTestAbstractScalar.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _scalar_arrays_2())
         class TestAsArrayLikeFunctions(
             AbstractTestAbstractScalar.TestArrayFunctions.TestAsArrayLikeFunctions,
         ):

--- a/named_arrays/_scalars/uncertainties/tests/test_uncertainties.py
+++ b/named_arrays/_scalars/uncertainties/tests/test_uncertainties.py
@@ -397,6 +397,13 @@ class AbstractTestAbstractUncertainScalarArray(
     ):
 
         @pytest.mark.parametrize("array_2", _uncertain_scalar_arrays_2())
+        class TestStackLikeFunctions(
+            named_arrays._scalars.tests.test_scalars.AbstractTestAbstractScalar.TestArrayFunctions
+            .TestStackLikeFunctions
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _uncertain_scalar_arrays_2())
         class TestAsArrayLikeFunctions(
             named_arrays._scalars.tests.test_scalars.AbstractTestAbstractScalar.TestArrayFunctions
             .TestAsArrayLikeFunctions

--- a/named_arrays/_scalars/uncertainties/uncertainties_array_functions.py
+++ b/named_arrays/_scalars/uncertainties/uncertainties_array_functions.py
@@ -623,8 +623,8 @@ def array_function_stack_like(
     arrays_distribution = []
 
     for array in arrays:
-        array = array.broadcasted
         if isinstance(array, na.AbstractArray):
+            array = array.broadcasted
             if isinstance(array, na.AbstractScalar):
                 if isinstance(array, na.AbstractUncertainScalarArray):
                     array_nominal = na.as_named_array(array.nominal)

--- a/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian_2d.py
+++ b/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian_2d.py
@@ -197,6 +197,12 @@ class AbstractTestAbstractCartesian2dVectorArray(
     ):
 
         @pytest.mark.parametrize("array_2", _cartesian2d_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _cartesian2d_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions
         ):

--- a/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian_3d.py
+++ b/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian_3d.py
@@ -202,6 +202,12 @@ class AbstractTestAbstractCartesian3dVectorArray(
     ):
 
         @pytest.mark.parametrize("array_2", _cartesian3d_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _cartesian3d_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions
         ):

--- a/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian_nd.py
+++ b/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian_nd.py
@@ -159,6 +159,12 @@ class AbstractTestAbstractCartesianNdVectorArray(
         test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions
     ):
         @pytest.mark.parametrize("array_2", _cartesian_nd_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _cartesian_nd_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions,
         ):

--- a/named_arrays/_vectors/tests/test_vectors_directional.py
+++ b/named_arrays/_vectors/tests/test_vectors_directional.py
@@ -70,6 +70,12 @@ class AbstractTestAbstractDirectionalVectorArray(
     ):
 
         @pytest.mark.parametrize("array_2", _directional_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _directional_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions
         ):

--- a/named_arrays/_vectors/tests/test_vectors_doppler.py
+++ b/named_arrays/_vectors/tests/test_vectors_doppler.py
@@ -92,6 +92,12 @@ class AbstractTestAbstractDopplerVectorArray(
     ):
 
         @pytest.mark.parametrize("array_2", _doppler_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _doppler_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions
         ):

--- a/named_arrays/_vectors/tests/test_vectors_doppler_positional.py
+++ b/named_arrays/_vectors/tests/test_vectors_doppler_positional.py
@@ -70,6 +70,12 @@ class AbstractTestAbstractDopplerPositionalVectorArray(
     ):
 
         @pytest.mark.parametrize("array_2", _doppler_positional_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _doppler_positional_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions,
         ):

--- a/named_arrays/_vectors/tests/test_vectors_input_output.py
+++ b/named_arrays/_vectors/tests/test_vectors_input_output.py
@@ -82,6 +82,12 @@ class AbstractTestAbstractInputOutputVectorArray(
     ):
 
         @pytest.mark.parametrize("array_2", _input_output_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _input_output_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions
         ):

--- a/named_arrays/_vectors/tests/test_vectors_positional.py
+++ b/named_arrays/_vectors/tests/test_vectors_positional.py
@@ -70,6 +70,12 @@ class AbstractTestAbstractPositionalVectorArray(
     ):
 
         @pytest.mark.parametrize("array_2", _positional_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _positional_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions
         ):

--- a/named_arrays/_vectors/tests/test_vectors_spectral.py
+++ b/named_arrays/_vectors/tests/test_vectors_spectral.py
@@ -68,6 +68,12 @@ class AbstractTestAbstractSpectralVectorArray(
     ):
 
         @pytest.mark.parametrize("array_2", _spectral_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _spectral_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions
         ):

--- a/named_arrays/_vectors/tests/test_vectors_spectral_directional.py
+++ b/named_arrays/_vectors/tests/test_vectors_spectral_directional.py
@@ -80,6 +80,12 @@ class AbstractTestAbstractSpectralDirectionalVectorArray(
     ):
 
         @pytest.mark.parametrize("array_2", _spectral_directional_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _spectral_directional_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions,
         ):

--- a/named_arrays/_vectors/tests/test_vectors_spectral_positional.py
+++ b/named_arrays/_vectors/tests/test_vectors_spectral_positional.py
@@ -79,6 +79,12 @@ class AbstractTestAbstractSpectralPositionalVectorArray(
     ):
 
         @pytest.mark.parametrize("array_2", _spectral_positional_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _spectral_positional_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions,
         ):

--- a/named_arrays/_vectors/tests/test_vectors_temporal.py
+++ b/named_arrays/_vectors/tests/test_vectors_temporal.py
@@ -67,6 +67,12 @@ class AbstractTestAbstractTemporalVectorArray(
     ):
 
         @pytest.mark.parametrize("array_2", _temporal_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _temporal_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions
         ):

--- a/named_arrays/_vectors/tests/test_vectors_temporal_doppler_positional.py
+++ b/named_arrays/_vectors/tests/test_vectors_temporal_doppler_positional.py
@@ -77,6 +77,12 @@ class AbstractTestAbstractTemporalDopplerPositionalVectorArray(
     ):
 
         @pytest.mark.parametrize("array_2", _temporal_doppler_positional_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _temporal_doppler_positional_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions,
         ):

--- a/named_arrays/_vectors/tests/test_vectors_temporal_positional.py
+++ b/named_arrays/_vectors/tests/test_vectors_temporal_positional.py
@@ -88,6 +88,12 @@ class AbstractTestAbstractTemporalPositionalVectorArray(
     ):
 
         @pytest.mark.parametrize("array_2", _temporal_positional_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _temporal_positional_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions,
         ):

--- a/named_arrays/_vectors/tests/test_vectors_temporal_spectral.py
+++ b/named_arrays/_vectors/tests/test_vectors_temporal_spectral.py
@@ -82,6 +82,12 @@ class AbstractTestAbstractTemporalSpectralVectorArray(
     ):
 
         @pytest.mark.parametrize("array_2", _temporal_spectral_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _temporal_spectral_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions,
         ):

--- a/named_arrays/_vectors/tests/test_vectors_temporal_spectral_directional.py
+++ b/named_arrays/_vectors/tests/test_vectors_temporal_spectral_directional.py
@@ -92,6 +92,12 @@ class AbstractTestAbstractTemporalSpectralDirectionalVectorArray(
     ):
 
         @pytest.mark.parametrize("array_2", _temporal_spectral_directional_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _temporal_spectral_directional_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions,
         ):

--- a/named_arrays/_vectors/tests/test_vectors_temporal_spectral_positional.py
+++ b/named_arrays/_vectors/tests/test_vectors_temporal_spectral_positional.py
@@ -92,6 +92,12 @@ class AbstractTestAbstractTemporalSpectralPositionalVectorArray(
     ):
 
         @pytest.mark.parametrize("array_2", _temporal_spectral_positional_arrays_2())
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", _temporal_spectral_positional_arrays_2())
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions,
         ):

--- a/named_arrays/_vectors/vector_array_functions.py
+++ b/named_arrays/_vectors/vector_array_functions.py
@@ -566,6 +566,11 @@ def array_function_stack_like(
             vector_prototype = array
             break
 
+    for array in arrays:
+        if isinstance(array, na.AbstractVectorArray):
+            if array.type_abstract != vector_prototype.type_abstract:
+                return NotImplemented
+
     arrays = [
         vector_prototype.type_explicit.from_scalar(
             scalar=a,

--- a/named_arrays/tests/test_core.py
+++ b/named_arrays/tests/test_core.py
@@ -1162,31 +1162,47 @@ class AbstractTestAbstractArray(
 
         @pytest.mark.parametrize('axis', ['y', 'z'])
         @pytest.mark.parametrize('use_out', [False, True])
-        def test_stack(
-                self,
-                array: na.AbstractArray,
-                axis: str,
-                use_out: bool,
-        ):
-            arrays = [array, array]
+        class TestStackLikeFunctions(abc.ABC):
 
-            if axis in array.axes:
-                with pytest.raises(ValueError, match=r"axis .* already in array"):
-                    np.stack(arrays, axis=axis)
-                return
+            def test_stack(
+                    self,
+                    array: na.AbstractArray,
+                    array_2: None | bool | int | float | complex | u.Quantity | na.AbstractArray,
+                    axis: str,
+                    use_out: bool,
+            ):
+                if array_2 is None:
+                    array_2 = array
 
-            if use_out:
-                out = 0 * np.stack(arrays=arrays, axis=axis)
-            else:
-                out = None
+                arrays = [array, array_2]
 
-            result = np.stack(arrays=arrays, axis=axis, out=out)
+                # if the binary ufunc dispatch rejects this combination of
+                # operands, stacking them must be rejected as well
+                try:
+                    np.equal(array, na.as_named_array(array_2))
+                except (ValueError, TypeError) as e:
+                    # expect the base class of the exception since the
+                    # implementation is free to order its checks differently
+                    error = ValueError if isinstance(e, ValueError) else TypeError
+                    with pytest.raises(error):
+                        np.stack(arrays, axis=axis)
+                    return
 
-            assert np.all(result[{axis: 0}] == array)
-            assert np.all(result[{axis: 1}] == array)
+                shape = na.shape_broadcasted(array, na.as_named_array(array_2))
+                if axis in shape:
+                    with pytest.raises(ValueError, match=r"axis .* already in array"):
+                        np.stack(arrays, axis=axis)
+                    return
 
-            if use_out:
-                assert result is out
+                result = np.stack(arrays=arrays, axis=axis)
+
+                if use_out:
+                    out = 0 * result
+                    result = np.stack(arrays=arrays, axis=axis, out=out)
+                    assert result is out
+
+                assert np.all(result[{axis: 0}] == array)
+                assert np.all(result[{axis: 1}] == array_2)
 
         @pytest.mark.parametrize('axis', ['x', 'y'])
         def test_concatenate(

--- a/named_arrays/tests/test_core.py
+++ b/named_arrays/tests/test_core.py
@@ -1161,7 +1161,6 @@ class AbstractTestAbstractArray(
             assert result.axes == tuple(shape.keys())
 
         @pytest.mark.parametrize('axis', ['y', 'z'])
-        @pytest.mark.parametrize('use_out', [False, True])
         class TestStackLikeFunctions(abc.ABC):
 
             def test_stack(
@@ -1169,7 +1168,6 @@ class AbstractTestAbstractArray(
                     array: na.AbstractArray,
                     array_2: None | bool | int | float | complex | u.Quantity | na.AbstractArray,
                     axis: str,
-                    use_out: bool,
             ):
                 if array_2 is None:
                     array_2 = array
@@ -1179,7 +1177,7 @@ class AbstractTestAbstractArray(
                 # if the binary ufunc dispatch rejects this combination of
                 # operands, stacking them must be rejected as well
                 try:
-                    np.equal(array, na.as_named_array(array_2))
+                    np.equal(array, array_2)
                 except (ValueError, TypeError) as e:
                     # expect the base class of the exception since the
                     # implementation is free to order its checks differently
@@ -1188,7 +1186,7 @@ class AbstractTestAbstractArray(
                         np.stack(arrays, axis=axis)
                     return
 
-                shape = na.shape_broadcasted(array, na.as_named_array(array_2))
+                shape = na.shape_broadcasted(array, array_2)
                 if axis in shape:
                     with pytest.raises(ValueError, match=r"axis .* already in array"):
                         np.stack(arrays, axis=axis)
@@ -1196,13 +1194,14 @@ class AbstractTestAbstractArray(
 
                 result = np.stack(arrays=arrays, axis=axis)
 
-                if use_out:
-                    out = 0 * result
-                    result = np.stack(arrays=arrays, axis=axis, out=out)
-                    assert result is out
-
                 assert np.all(result[{axis: 0}] == array)
                 assert np.all(result[{axis: 1}] == array_2)
+
+                out = 0 * result
+                result_out = np.stack(arrays=arrays, axis=axis, out=out)
+
+                assert result_out is out
+                assert np.all(result_out == result)
 
         @pytest.mark.parametrize('axis', ['x', 'y'])
         def test_concatenate(


### PR DESCRIPTION
Fixes #190

## Summary

- `np.stack`/`np.concatenate` raised `AttributeError: 'Quantity' object has no 'broadcasted' member` when the input list mixed a plain `Quantity` (or float) with an `UncertainScalarArray`: the uncertainties stack implementation accessed `.broadcasted` on every input before the `isinstance` checks, making the plain-input promotion branch unreachable. The `.broadcasted` access now happens only for named-array inputs.
- While generalizing the tests, a second hole of the same class surfaced: the vector-family stack implementation silently accepted structurally incompatible inputs (a flat matrix stacked with a nested matrix, or two different vector families) and produced a result with scrambled component nesting (e.g. a vector-of-matrices instead of a matrix-of-vectors, unverifiable even via `cartesian_nd`). It now returns `NotImplemented` when a vector input does not share the `type_abstract` of the prototype, so such combinations raise `TypeError` — consistent with the binary ufunc dispatch, which already rejects them.

## Tests

`AbstractTestAbstractArray.TestArrayFunctions.test_stack` moved into a `TestStackLikeFunctions` nested class with a new `array_2` argument, parametrized in each family test module with its `_arrays_2()` instances (mirroring `TestAsArrayLikeFunctions`), so stacking is now exercised across mixed kinds, units, and shapes in every family. The test uses `np.equal` as the oracle: if the binary ufunc dispatch rejects a pair of operands, `np.stack` must reject it with the same class of error; otherwise the stacked result must round-trip both operands. Matrices re-parametrize with matrix instances (matrix-vs-vector binary ops are undefined), and functions expect `TypeError` for non-function operands since there is no way to promote them to a `FunctionArray`.

`pytest -k "test_stack or test_concatenate"`: 17396 passed (previously ~4300 cases, none mixing kinds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lm9SxSpyNg9hx8dNL9pUXc