### PR TITLE
Add `na.transformations.compose`

### DIFF
--- a/named_arrays/tests/test_transformations.py
+++ b/named_arrays/tests/test_transformations.py
@@ -239,4 +239,35 @@ class TestTransformationList(
     pass
 
 
+@pytest.mark.parametrize("a", transformations_basic)
+@pytest.mark.parametrize("b", transformations_basic)
+def test_compose(
+    a: na.transformations.AbstractTransformation,
+    b: na.transformations.AbstractTransformation,
+):
+    result = na.transformations.compose(a, b)
+
+    v = na.Cartesian3dVectorArray(1, 2, 3) * u.mm
+
+    # `compose` is a wrapper around the `@` operator
+    assert np.allclose(result(v), (a @ b)(v))
+
+    # composition is right-to-left: `b` is applied first, then `a`
+    assert np.allclose(result(v), a(b(v)))
+
+
+@pytest.mark.parametrize("a", transformations)
+def test_compose_none(
+    a: na.transformations.AbstractTransformation,
+):
+    # a `None` argument acts as the identity: it is dropped from the
+    # composition and the other argument is returned unchanged
+    assert na.transformations.compose(a, None) is a
+    assert na.transformations.compose(None, a) is a
+
+
+def test_compose_none_none():
+    assert na.transformations.compose(None, None) is None
+
+
 

--- a/named_arrays/transformations.py
+++ b/named_arrays/transformations.py
@@ -13,6 +13,7 @@ import astropy.units as u
 import named_arrays as na
 
 __all__ = [
+    "compose",
     "AbstractTransformation",
     "IdentityTransformation",
     "AbstractTranslation",
@@ -35,6 +36,73 @@ MatrixT = TypeVar("MatrixT", bound="na.AbstractMatrixArray")
 TransformationT = TypeVar("TransformationT", bound="AbstractTransformation")
 LinearTransformationT = TypeVar("LinearTransformationT", bound="AbstractLinearTransformation")
 TranslationT = TypeVar("TranslationT", bound="AbstractTranslation")
+
+
+def compose(
+    a: None | AbstractTransformation,
+    b: None | AbstractTransformation,
+) -> None | AbstractTransformation:
+    r"""
+    Compose two transformations, treating :obj:`None` as the identity.
+
+    This is a convenience wrapper around the ``@`` operator that accepts
+    :obj:`None` for either argument, which is useful when composing optional
+    transformations without having to guard each one. Composition follows the
+    same right-to-left convention as :meth:`AbstractTransformation.__matmul__`:
+    the result applied to a vector :math:`\vec{v}` is :math:`a(b(\vec{v}))`, so
+    `b` is applied first and `a` second.
+
+    Parameters
+    ----------
+    a
+        The outer transformation, applied second.
+        If :obj:`None`, it is treated as the identity and `b` is returned
+        unchanged.
+    b
+        The inner transformation, applied first.
+        If :obj:`None`, it is treated as the identity and `a` is returned
+        unchanged.
+
+    Returns
+    -------
+        The composition ``a @ b``, or :obj:`None` if both `a` and `b` are
+        :obj:`None`.
+
+    Examples
+    --------
+    Compose a rotation with a translation and apply the result to a vector.
+
+    .. jupyter-execute::
+
+        import astropy.units as u
+        import named_arrays as na
+
+        a = na.transformations.Cartesian3dTranslation(x=5 * u.mm)
+        b = na.transformations.Cartesian3dRotationZ(90 * u.deg)
+
+        transformation = na.transformations.compose(a, b)
+
+        v = na.Cartesian3dVectorArray(1, 2, 3) * u.mm
+        transformation(v)
+
+    This is equivalent to applying each transformation in turn.
+
+    .. jupyter-execute::
+
+        a(b(v))
+
+    A :obj:`None` argument acts as the identity, so it is dropped from the
+    composition and the other transformation is returned unchanged.
+
+    .. jupyter-execute::
+
+        na.transformations.compose(a, None) is a
+    """
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a @ b
 
 
 @dataclasses.dataclass(eq=False)


### PR DESCRIPTION
Add a `compose(a, b)` helper for composing two transformations while treating `None` as the identity.

This makes it easy to combine *optional* transformations without guarding each argument:

- `compose(a, None)` returns `a` unchanged (by identity)
- `compose(None, b)` returns `b` unchanged (by identity)
- `compose(None, None)` returns `None`
- otherwise it is equivalent to `a @ b`

Composition follows the same right-to-left convention as `AbstractTransformation.__matmul__`, so `compose(a, b)` applied to a vector `v` is `a(b(v))`.

### Changes
- Add `na.transformations.compose` (exported via `__all__`) with a docstring documenting the None-as-identity behavior and composition order, plus a runnable example.
- Add `test_compose`, `test_compose_none`, and `test_compose_none_none` covering the `@`-operator equivalence, the right-to-left semantics, and the None handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWk1x6S9g3s8o674HJUqRQ