### PR TITLE
Accept a scalar-array `num` in `linspace`/`logspace`/`geomspace`

### DIFF
--- a/named_arrays/_scalars/scalar_array_functions.py
+++ b/named_arrays/_scalars/scalar_array_functions.py
@@ -163,6 +163,12 @@ def array_function_sequence(
         else:
             return NotImplemented
 
+    if isinstance(num, na.AbstractArray):
+        if isinstance(num, na.AbstractScalarArray):
+            num = num.ndarray
+        else:
+            return NotImplemented
+
     return na.ScalarArray(
         ndarray=func(
             *args,

--- a/named_arrays/tests/test_core.py
+++ b/named_arrays/tests/test_core.py
@@ -22,6 +22,37 @@ def _normalize_shape(shape: dict[str, None | int]) -> dict[str, int]:
     return {axis: shape[axis] for axis in shape if shape[axis] is not None}
 
 
+def test_linspace_num_scalar_array():
+    # `num` given as a 0-d integer scalar array must be accepted, both directly
+    # and as the per-component values produced when `linspace` decomposes a
+    # vector `num`.
+
+    # scalar `num` as a 0-d `ScalarArray`
+    result = na.linspace(0, 10, axis="x", num=na.ScalarArray(np.array(4)))
+    assert np.all(result == na.linspace(0, 10, axis="x", num=4))
+
+    # vector `num` whose components are `ScalarArray` instances
+    result = na.linspace(
+        start=na.Cartesian2dVectorArray(
+            x=na.ScalarArray(np.array(0.0)),
+            y=na.ScalarArray(np.array(0.0)),
+        ),
+        stop=na.Cartesian2dVectorArray(
+            x=na.ScalarArray(np.array(10.0)),
+            y=na.ScalarArray(np.array(8.0)),
+        ),
+        axis=na.Cartesian2dVectorArray("x", "y"),
+        num=na.Cartesian2dVectorArray(
+            x=na.ScalarArray(np.array(5)),
+            y=na.ScalarArray(np.array(4)),
+        ),
+    )
+    assert isinstance(result, na.Cartesian2dVectorArray)
+    assert na.shape(result) == {"x": 5, "y": 4}
+    assert np.all(result.x == na.linspace(0, 10, axis="x", num=5))
+    assert np.all(result.y == na.linspace(0, 8, axis="y", num=4))
+
+
 @pytest.mark.parametrize(argnames='shape_1_x', argvalues=[num_x], )
 @pytest.mark.parametrize(argnames='shape_1_y', argvalues=[num_y], )
 @pytest.mark.parametrize(argnames='shape_2_x', argvalues=[None, 1, num_x], )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ Documentation = "https://named-arrays.readthedocs.io/en/latest"
 
 [tool.setuptools_scm]
 
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+
 [tool.setuptools.package-data]
 named_arrays = ["py.typed"]
 


### PR DESCRIPTION
## Summary

`na.linspace` (and `logspace`/`geomspace`) raised `TypeError: 'ScalarArray' object cannot be interpreted as an integer` when given a **vector** `num` whose components are `ScalarArray` instances.

The vector sequence handler (`_vectors/vector_array_functions.py`) decomposes a vector `num` into its components and forwards each to the scalar handler. The scalar handler (`_scalars/scalar_array_functions.py`) passed `num` straight to numpy, which cannot interpret a `ScalarArray` as an integer. So na-linspace's own vector path emitted a per-component `num` shape its scalar path could not consume.

## Fix

In the scalar sequence handler, coerce a scalar-array `num` to its `ndarray` (a 0-d integer array, which numpy accepts), mirroring the existing handling of `axis` a few lines above. This fixes the vector path and additionally lets a 0-d integer `ScalarArray` be used as `num` directly.

## Repro

```python
import numpy as np, astropy.units as u, named_arrays as na

na.linspace(
    start=na.Cartesian2dVectorArray(x=na.ScalarArray(0 * u.nm), y=na.ScalarArray(0 * u.nm)),
    stop=na.Cartesian2dVectorArray(x=na.ScalarArray(10 * u.nm), y=na.ScalarArray(8 * u.nm)),
    axis=na.Cartesian2dVectorArray("x", "y"),
    num=na.Cartesian2dVectorArray(x=na.ScalarArray(np.array(5)), y=na.ScalarArray(np.array(4))),
)  # TypeError before this change
```

## Tests

Adds `test_linspace_num_scalar_array` covering both a 0-d `ScalarArray` `num` and a vector `num` with `ScalarArray` components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtdKmedevWkDab6BWupXqQ