### PR TITLE
Add a spectral_positional conversion property

### DIFF
--- a/named_arrays/_vectors/tests/test_vectors_doppler_positional.py
+++ b/named_arrays/_vectors/tests/test_vectors_doppler_positional.py
@@ -53,6 +53,14 @@ class AbstractTestAbstractDopplerPositionalVectorArray(
     ):
         super().test__getitem__(array=array, item=item)
 
+    def test_spectral_positional(
+        self, array: na.AbstractDopplerPositionalVectorArray
+    ):
+        result = array.spectral_positional
+        assert isinstance(result, na.SpectralPositionalVectorArray)
+        assert np.all(result.wavelength == array.wavelength)
+        assert np.all(result.position == array.position)
+
     @pytest.mark.parametrize('array_2', _doppler_positional_arrays_2())
     class TestUfuncBinary(
         test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestUfuncBinary

--- a/named_arrays/_vectors/tests/test_vectors_spectral_positional.py
+++ b/named_arrays/_vectors/tests/test_vectors_spectral_positional.py
@@ -85,6 +85,14 @@ class AbstractTestAbstractSpectralPositionalVectorArray(
         # order in which they are given does not matter
         assert np.all(result == array.volume_cell(tuple(reversed(axis))))
 
+    def test_spectral_positional(
+        self, array: na.AbstractSpectralPositionalVectorArray
+    ):
+        result = array.spectral_positional
+        assert isinstance(result, na.SpectralPositionalVectorArray)
+        assert np.all(result.wavelength == array.wavelength)
+        assert np.all(result.position == array.position)
+
     @pytest.mark.parametrize('array_2', _spectral_positional_arrays_2())
     class TestUfuncBinary(
         test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestUfuncBinary

--- a/named_arrays/_vectors/vectors_doppler_positional.py
+++ b/named_arrays/_vectors/vectors_doppler_positional.py
@@ -31,6 +31,22 @@ class AbstractDopplerPositionalVectorArray(
     def type_matrix(self) -> Type[na.AbstractMatrixArray]:
         return na.DopplerPositionalMatrixArray
 
+    @property
+    def spectral_positional(self) -> na.SpectralPositionalVectorArray:
+        """
+        This Doppler vector as a plain
+        :class:`~named_arrays.SpectralPositionalVectorArray`, keeping only the
+        observed wavelength and position (the rest wavelength is discarded).
+
+        This lets a caller accept either a spectral- or Doppler-positional grid
+        and normalize it to a spectral-positional vector with a single property
+        access, e.g. to compute :meth:`volume_cell`.
+        """
+        return na.SpectralPositionalVectorArray(
+            wavelength=self.wavelength,
+            position=self.position,
+        )
+
 
 @dataclasses.dataclass(eq=False, repr=False)
 class DopplerPositionalVectorArray(

--- a/named_arrays/_vectors/vectors_spectral_positional.py
+++ b/named_arrays/_vectors/vectors_spectral_positional.py
@@ -34,6 +34,22 @@ class AbstractSpectralPositionalVectorArray(
     def type_matrix(self) -> Type[na.SpectralPositionalMatrixArray]:
         return na.SpectralPositionalMatrixArray
 
+    @property
+    def spectral_positional(self) -> "SpectralPositionalVectorArray":
+        """
+        This vector as a plain :class:`SpectralPositionalVectorArray`,
+        exposing only its wavelength and position.
+
+        The same property on other wavelength-and-position vectors, such as
+        :class:`~named_arrays.AbstractDopplerPositionalVectorArray`, projects
+        onto this representation, so a caller can accept either type and
+        normalize it with a single property access.
+        """
+        return SpectralPositionalVectorArray(
+            wavelength=self.wavelength,
+            position=self.position,
+        )
+
     def volume_cell(self, axis: None | str | Sequence[str]) -> na.AbstractScalar:
         """
         The volume of each voxel of the logically-rectangular grid formed by


### PR DESCRIPTION
## Summary

Adds a `spectral_positional` property to both `AbstractSpectralPositionalVectorArray` and `AbstractDopplerPositionalVectorArray`, returning a plain `SpectralPositionalVectorArray` built from the vector's observed wavelength and position.

## Motivation

Both classes describe a wavelength-and-position grid, but spectral-positional-only operations (notably `volume_cell`) are implemented only on `AbstractSpectralPositionalVectorArray`. Calling them on a Doppler-positional grid raises `NotImplementedError`, so downstream consumers that accept either type (optika's `LinearSystem`, ctis's instruments and `regrid`) had to rebuild

```python
na.SpectralPositionalVectorArray(wavelength=coords.wavelength, position=coords.position)
```

by hand at every call site. This kept recurring as new consumers appeared.

## Change

A single property lets a caller normalize either grid type in one access:

```python
coordinates.spectral_positional.volume_cell(axis)
```

For a Doppler vector the rest wavelength is discarded, keeping only the observed wavelength and position. It's a new property on the abstract classes — no type relationships change (unlike making Doppler *inherit* the spectral-positional type), so it avoids any isinstance/shared-test-suite fallout.

## Tests

`test_spectral_positional` added to the abstract test classes for both families, so it runs across every concrete subclass (explicit, linear space, Doppler, and the temporal variants) — asserting the result is a `SpectralPositionalVectorArray` with matching wavelength and position. Full vector test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtdKmedevWkDab6BWupXqQ
