### PR TITLE
Add `na.plt.HypercubeSlicer`, an interactive 4D spectral-cube viewer

### DIFF
--- a/named_arrays/plt.py
+++ b/named_arrays/plt.py
@@ -2508,11 +2508,15 @@ class HypercubeSlicer:
     with colorbars in dedicated slots of the grid:
 
     - The `image` panel (upper left, largest) displays the current time step,
-      either integrated over the wavelength axis (``"intensity"`` mode)
+      either integrated over the wavelength coordinate (``"intensity"`` mode,
+      a sum over the wavelength axis weighted by the mean coordinate cell
+      width, so its unit is the product of the outputs and coordinate units)
       or as the intensity-weighted mean wavelength coordinate
       (``"doppler"`` mode).
       Crosshairs mark the currently-selected spatial point,
       and the panel's colorbar updates with the mode.
+      Every label is built from the logical axis names given by the caller
+      and the units read from the coordinates of ``function.inputs``.
     - The `vertical slit` panel (upper right) displays wavelength (horizontal)
       vs. vertical position for the selected column of the image,
       the spectrum a spectrograph with a vertical slit through the selected
@@ -2717,10 +2721,25 @@ class HypercubeSlicer:
         self._cmap = cmap
         self._cmap_doppler = cmap_doppler
 
+        # The mean cell width of the wavelength coordinate, used to weight
+        # the sum over the wavelength axis so that the image panel displays
+        # an integral over the coordinate, with units given by the product of
+        # the outputs and wavelength-coordinate units.
+        dwavelength = np.abs(
+            np.diff(
+                wavelength.value.ndarray,
+                axis=wavelength.axes.index(axis_wavelength),
+            )
+        )
+        dwavelength = float(np.nanmean(dwavelength)) if dwavelength.size else 1.0
+        if not dwavelength > 0:
+            dwavelength = 1.0
+        self._dwavelength = dwavelength
+
         # Global, data-derived color scales, computed once at construction so
         # that no panel ever rescales while scrolling through time or
         # selecting new points.
-        intensity = outputs.sum(axis_wavelength).value.ndarray
+        intensity = dwavelength * outputs.sum(axis_wavelength).value.ndarray
         vmin_intensity, vmax_intensity = np.nanpercentile(intensity, percentile)
         self._norm_intensity = matplotlib.colors.Normalize(
             vmin=vmin_intensity,
@@ -2763,13 +2782,27 @@ class HypercubeSlicer:
             vmax=center + halfrange,
         )
 
+        # Every label is built from the logical axis names given by the
+        # caller and the units read from the corresponding coordinates of
+        # `function.inputs`, when they exist.
         unit_wavelength = na.unit(wavelength.ndarray)
         unit_outputs = na.unit(outputs.ndarray)
         if getattr(inputs, "wavelength", None) is not None:
             self._label_wavelength = self._label(axis_wavelength, unit_wavelength)
+            self._label_doppler = self._label(
+                name=f"mean {axis_wavelength}",
+                unit=unit_wavelength,
+            )
         else:
             self._label_wavelength = f"{axis_wavelength} (index)"
-        self._label_intensity = self._label("intensity", unit_outputs)
+            self._label_doppler = f"mean {axis_wavelength} (index)"
+        if unit_outputs is not None and unit_wavelength is not None:
+            unit_intensity = unit_outputs * unit_wavelength
+        elif unit_outputs is not None:
+            unit_intensity = unit_outputs
+        else:
+            unit_intensity = unit_wavelength
+        self._label_intensity = self._label("intensity", unit_intensity)
         self._label_outputs = self._label("outputs", unit_outputs)
 
         kwargs_figure.setdefault("figsize", (11, 8))
@@ -3012,18 +3045,20 @@ class HypercubeSlicer:
         if self._mode == "intensity":
             return self._label_intensity
         else:
-            return self._label_wavelength
+            return self._label_doppler
 
     def _data_image(self) -> np.ndarray:
         """The current contents of the image panel."""
         item = {self._axis_time: self._index_time}
         outputs = self._outputs[item]
+        axes = (self._axis_y, self._axis_x)
         if self._mode == "intensity":
             result = outputs.sum(self._axis_wavelength)
+            return self._dwavelength * result.value.ndarray_aligned(axes)
         else:
             wavelength = self._get_item(self._wavelength, item)
             result = self._moment(outputs, wavelength)
-        return result.value.ndarray_aligned((self._axis_y, self._axis_x))
+            return result.value.ndarray_aligned(axes)
 
     def _data_slit_vertical(self) -> np.ndarray:
         """The current contents of the vertical-slit panel."""

--- a/named_arrays/plt.py
+++ b/named_arrays/plt.py
@@ -2537,6 +2537,9 @@ class HypercubeSlicer:
     and the Doppler norm is symmetric about the global intensity-weighted
     mean wavelength coordinate with a half-range given by a high percentile
     of the per-pixel first-moment deviation from that center.
+    Like :mod:`xarray`, each colorbar draws a pointed ``extend`` arrow on
+    any side where its norm clips the global range of the quantity it
+    displays, so saturation of the color scale is always visible.
     The vertical limits of the spectrum panel span the extrema over time of
     the selected pixel's spectra, and are only recomputed when a new point
     is selected.
@@ -2748,8 +2751,9 @@ class HypercubeSlicer:
 
         # The two slit panels display the same physical quantity, so they
         # share a single norm derived from the full 4-dimensional cube.
+        outputs_ndarray = outputs.value.ndarray
         vmin_spectrum, vmax_spectrum = np.nanpercentile(
-            outputs.value.ndarray,
+            outputs_ndarray,
             percentile,
         )
         self._norm_spectrum = matplotlib.colors.Normalize(
@@ -2766,11 +2770,10 @@ class HypercubeSlicer:
         # given by a high percentile of the deviation of the per-pixel first
         # moment from that center over all times.
         center = (wavelength * outputs).sum() / outputs.sum()
-        deviation = np.abs(self._moment(outputs, wavelength) - center)
+        moment = self._moment(outputs, wavelength).value.ndarray
+        deviation = np.abs(moment - float(center.value.ndarray))
         center = float(center.value.ndarray)
-        halfrange = float(
-            np.nanpercentile(deviation.value.ndarray, percentile[~0]),
-        )
+        halfrange = float(np.nanpercentile(deviation, percentile[~0]))
         if not halfrange > 0:
             halfrange = max(
                 center - self._wavelength_min,
@@ -2780,6 +2783,25 @@ class HypercubeSlicer:
         self._norm_doppler = matplotlib.colors.Normalize(
             vmin=center - halfrange,
             vmax=center + halfrange,
+        )
+
+        # Each colorbar advertises whether its norm clips the global range of
+        # the quantity it describes, using pointed "extend" arrows on the
+        # clipped side, like `xarray`.
+        self._extend_intensity = self._extend(
+            norm=self._norm_intensity,
+            vmin=np.nanmin(intensity),
+            vmax=np.nanmax(intensity),
+        )
+        self._extend_doppler = self._extend(
+            norm=self._norm_doppler,
+            vmin=np.nanmin(moment),
+            vmax=np.nanmax(moment),
+        )
+        self._extend_slit = self._extend(
+            norm=self._norm_spectrum,
+            vmin=np.nanmin(outputs_ndarray),
+            vmax=np.nanmax(outputs_ndarray),
         )
 
         # Every label is built from the logical axis names given by the
@@ -2819,8 +2841,9 @@ class HypercubeSlicer:
             width_ratios=(width_ratios[0], width_cax, width_ratios[1], width_cax),
             height_ratios=height_ratios,
         )
+        self._subplotspec_cax_image = gridspec[0, 1]
         self.ax_image = self._fig.add_subplot(gridspec[0, 0])
-        self.cax_image = self._fig.add_subplot(gridspec[0, 1])
+        self.cax_image = self._fig.add_subplot(self._subplotspec_cax_image)
         self.ax_slit_vertical = self._fig.add_subplot(
             gridspec[0, 2],
             sharey=self.ax_image,
@@ -2857,14 +2880,12 @@ class HypercubeSlicer:
             **kwargs_imshow,
         )
 
-        self._colorbar_image = self._fig.colorbar(
-            self._img_image,
-            cax=self.cax_image,
-        )
-        self._colorbar_image.set_label(self._label_colorbar_image)
+        self._colorbar_image = None
+        self._update_colorbar_image()
         self._colorbar_slit = self._fig.colorbar(
             self._img_slit_vertical,
             cax=self.cax_slit,
+            extend=self._extend_slit,
         )
         self._colorbar_slit.set_label(self._label_outputs)
 
@@ -3000,6 +3021,7 @@ class HypercubeSlicer:
             )
         self._mode = mode
         self._update_image()
+        self._update_colorbar_image()
         self._fig.canvas.draw_idle()
 
     @staticmethod
@@ -3008,6 +3030,24 @@ class HypercubeSlicer:
         if unit is not None and unit != u.dimensionless_unscaled:
             return f"{name} ({unit})"
         return name
+
+    @staticmethod
+    def _extend(
+        norm: matplotlib.colors.Normalize,
+        vmin: float,
+        vmax: float,
+    ) -> str:
+        """The colorbar `extend` style for data spanning `vmin` to `vmax`."""
+        clip_min = vmin < norm.vmin
+        clip_max = vmax > norm.vmax
+        if clip_min and clip_max:
+            return "both"
+        elif clip_min:
+            return "min"
+        elif clip_max:
+            return "max"
+        else:
+            return "neither"
 
     @staticmethod
     def _get_item(a: na.AbstractScalarArray, item: dict[str, int]):
@@ -3046,6 +3086,13 @@ class HypercubeSlicer:
             return self._label_intensity
         else:
             return self._label_doppler
+
+    @property
+    def _extend_image(self) -> str:
+        if self._mode == "intensity":
+            return self._extend_intensity
+        else:
+            return self._extend_doppler
 
     def _data_image(self) -> np.ndarray:
         """The current contents of the image panel."""
@@ -3115,8 +3162,26 @@ class HypercubeSlicer:
         self._img_image.set_data(self._data_image())
         self._img_image.set_cmap(self._cmap_image)
         self._img_image.set_norm(self._norm_image)
-        self._colorbar_image.set_label(self._label_colorbar_image)
         self._update_title()
+
+    def _update_colorbar_image(self) -> None:
+        """
+        Draw a fresh colorbar for the image panel.
+
+        A colorbar cannot change its `extend` style in place, so the colorbar
+        is drawn fresh on every mode switch, into a new axes occupying the
+        same dedicated slot of the gridspec so that the layout stays
+        deterministic.
+        """
+        if self._colorbar_image is not None:
+            self._colorbar_image.remove()
+            self.cax_image = self._fig.add_subplot(self._subplotspec_cax_image)
+        self._colorbar_image = self._fig.colorbar(
+            self._img_image,
+            cax=self.cax_image,
+            extend=self._extend_image,
+        )
+        self._colorbar_image.set_label(self._label_colorbar_image)
 
     def _update_spectrum_ylim(self) -> None:
         """

--- a/named_arrays/plt.py
+++ b/named_arrays/plt.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 from typing import Literal, Any, Callable, TypeVar
 import matplotlib.axes
+import matplotlib.figure
 import matplotlib.transforms
 import matplotlib.animation
 import matplotlib.text
 import matplotlib.colors
+import matplotlib.backend_bases
 import matplotlib.pyplot as plt
 import astropy.units as u
 import numpy as np
@@ -54,6 +56,7 @@ __all__ = [
     "twiny",
     "invert_xaxis",
     "invert_yaxis",
+    "HypercubeSlicer",
 ]
 
 
@@ -2491,3 +2494,559 @@ def dimension(
     )
 
     return result
+
+
+class HypercubeSlicer:
+    """
+    An interactive :mod:`matplotlib` viewer for a 4-dimensional
+    spectral-imaging time series.
+
+    The data to visualize is an instance of
+    :class:`named_arrays.FunctionArray` whose ``outputs`` has a temporal,
+    a spectral, and two spatial logical axes.
+    The figure is a 2 :math:`\\times` 2 mosaic of four panels:
+
+    - The `image` panel (upper left, largest) displays the current time step,
+      either integrated over the wavelength axis (``"intensity"`` mode)
+      or as the intensity-weighted mean wavelength coordinate
+      (``"doppler"`` mode).
+      Crosshairs mark the currently-selected spatial point.
+    - The `vertical slit` panel (upper right) displays wavelength (horizontal)
+      vs. vertical position for the selected column of the image,
+      the spectrum a spectrograph with a vertical slit through the selected
+      point would measure.
+    - The `horizontal slit` panel (lower left) displays horizontal position
+      vs. wavelength (vertical) for the selected row of the image.
+    - The `spectrum` panel (lower right) displays the spectrum of the single
+      selected pixel, with a vertical line marking its mean wavelength
+      coordinate.
+
+    The viewer is interactive:
+    left-clicking anywhere on the image panel selects a new spatial point,
+    scrolling the mouse wheel or pressing the left/right arrow keys steps
+    through the time axis,
+    and pressing the ``m`` key toggles between ``"intensity"`` and
+    ``"doppler"`` modes.
+    The same operations are available programmatically through
+    :meth:`set_point`, :meth:`set_time`, and :meth:`set_mode`.
+
+    Parameters
+    ----------
+    function
+        The spectral-imaging time series to visualize.
+        ``function.outputs`` must include the four logical axes given by
+        `axis_time`, `axis_wavelength`, `axis_x`, and `axis_y`.
+        If ``function.inputs`` has a ``wavelength`` component,
+        it is used as the wavelength coordinate,
+        otherwise the index along `axis_wavelength` is used.
+        If ``function.inputs`` has a ``time`` component,
+        it is displayed in the title of the image panel.
+    axis_time
+        The name of the logical axis representing time.
+    axis_wavelength
+        The name of the logical axis representing changing wavelength.
+    axis_x
+        The name of the logical axis representing horizontal position.
+    axis_y
+        The name of the logical axis representing vertical position.
+    index_time
+        The initial index along `axis_time` to display.
+    index_x
+        The initial selected index along `axis_x`.
+        If :obj:`None`, the middle of the axis is used.
+    index_y
+        The initial selected index along `axis_y`.
+        If :obj:`None`, the middle of the axis is used.
+    mode
+        The initial display mode of the image panel,
+        either ``"intensity"`` or ``"doppler"``.
+    cmap
+        The colormap used by the image panel in ``"intensity"`` mode and by
+        the two slit-spectrum panels.
+        If :obj:`None`, the default :mod:`matplotlib` colormap is used.
+    cmap_doppler
+        The colormap used by the image panel in ``"doppler"`` mode.
+    percentile
+        The lower and upper percentiles of the data used to compute the
+        color scale.
+    width_ratios
+        The relative widths of the left and right columns of the figure.
+    height_ratios
+        The relative heights of the upper and lower rows of the figure.
+    kwargs_figure
+        Additional keyword arguments passed to
+        :func:`matplotlib.pyplot.figure`.
+
+    Examples
+    --------
+
+    Visualize a moving Gaussian blob with a spatially-varying Doppler shift.
+
+    .. jupyter-execute::
+
+        import numpy as np
+        import astropy.units as u
+        import named_arrays as na
+
+        # Define the shape of the spectral cube
+        shape = dict(time=5, wavelength=11, x=32, y=32)
+
+        # Define the coordinates of the spectral cube
+        time = na.linspace(0, 20, axis="time", num=shape["time"]) * u.s
+        wavelength = na.linspace(-1, 1, axis="wavelength", num=shape["wavelength"])
+        x = na.linspace(-1, 1, axis="x", num=shape["x"])
+        y = na.linspace(-1, 1, axis="y", num=shape["y"])
+
+        # Define a Gaussian blob that moves horizontally with time
+        center = 0.5 * np.sin(2 * np.pi * u.rad * time / (25 * u.s))
+        blob = np.exp(-(np.square(x - center) + np.square(y)) / np.square(0.4))
+
+        # Define a spectral line whose Doppler shift varies with position
+        line = np.exp(-np.square(wavelength - 0.5 * x) / np.square(0.3))
+
+        # Combine into a 4-dimensional spectral cube
+        outputs = blob * line * u.photon
+
+        # Define the function array to visualize
+        function = na.FunctionArray(
+            inputs=na.TemporalSpectralPositionalVectorArray(
+                time=time,
+                wavelength=500 * u.nm + wavelength * u.nm,
+                position=na.Cartesian2dVectorArray(x, y),
+            ),
+            outputs=outputs,
+        )
+
+        # Create the interactive visualization
+        slicer = na.plt.HypercubeSlicer(
+            function,
+            axis_time="time",
+            axis_wavelength="wavelength",
+            axis_x="x",
+            axis_y="y",
+        )
+    """
+
+    def __init__(
+        self,
+        function: na.AbstractFunctionArray,
+        axis_time: str = "time",
+        axis_wavelength: str = "wavelength",
+        axis_x: str = "x",
+        axis_y: str = "y",
+        index_time: int = 0,
+        index_x: None | int = None,
+        index_y: None | int = None,
+        mode: Literal["intensity", "doppler"] = "intensity",
+        cmap: None | str | matplotlib.colors.Colormap = None,
+        cmap_doppler: None | str | matplotlib.colors.Colormap = "RdBu_r",
+        percentile: tuple[float, float] = (0.1, 99.9),
+        width_ratios: tuple[float, float] = (2.5, 1),
+        height_ratios: tuple[float, float] = (2.5, 1),
+        **kwargs_figure,
+    ):
+        outputs = na.as_named_array(function.outputs).explicit
+
+        axes = (axis_time, axis_wavelength, axis_x, axis_y)
+        for axis in axes:
+            if axis not in outputs.shape:
+                raise ValueError(
+                    f"axis {axis!r} is not in the shape of `function.outputs`,"
+                    f" {outputs.shape}."
+                )
+
+        self._axis_time = axis_time
+        self._axis_wavelength = axis_wavelength
+        self._axis_x = axis_x
+        self._axis_y = axis_y
+        self._outputs = outputs
+        self._shape = {axis: outputs.shape[axis] for axis in axes}
+
+        inputs = function.inputs
+
+        wavelength = getattr(inputs, "wavelength", None)
+        if wavelength is None:
+            wavelength = na.ScalarArray(
+                ndarray=np.arange(self._shape[axis_wavelength]),
+                axes=(axis_wavelength,),
+            )
+        else:
+            wavelength = na.as_named_array(wavelength).explicit
+        if axis_wavelength not in wavelength.shape:
+            wavelength = wavelength.broadcast_to(
+                shape=wavelength.shape | {axis_wavelength: self._shape[axis_wavelength]},
+            )
+        self._wavelength = wavelength
+
+        time = getattr(inputs, "time", None)
+        if time is not None:
+            time = na.as_named_array(time).explicit
+        self._time = time
+
+        if mode not in ("intensity", "doppler"):
+            raise ValueError(
+                f"mode must be 'intensity' or 'doppler', got {mode!r}."
+            )
+        self._mode = mode
+
+        self._index_time = int(index_time) % self._shape[axis_time]
+        if index_x is None:
+            index_x = self._shape[axis_x] // 2
+        if index_y is None:
+            index_y = self._shape[axis_y] // 2
+        self._index_x = int(index_x)
+        self._index_y = int(index_y)
+
+        self._cmap = cmap
+        self._cmap_doppler = cmap_doppler
+
+        intensity = outputs.sum(axis_wavelength).value.ndarray
+        self._vmin_intensity, self._vmax_intensity = np.nanpercentile(
+            intensity,
+            percentile,
+        )
+        self._vmin_spectrum, self._vmax_spectrum = np.nanpercentile(
+            outputs.value.ndarray,
+            percentile,
+        )
+        wavelength_ndarray = wavelength.value.ndarray
+        self._vmin_doppler = np.nanmin(wavelength_ndarray)
+        self._vmax_doppler = np.nanmax(wavelength_ndarray)
+
+        kwargs_figure.setdefault("figsize", (10, 8))
+        kwargs_figure.setdefault("constrained_layout", True)
+        self._fig = plt.figure(**kwargs_figure)
+
+        gridspec = self._fig.add_gridspec(
+            nrows=2,
+            ncols=2,
+            width_ratios=width_ratios,
+            height_ratios=height_ratios,
+        )
+        self.ax_image = self._fig.add_subplot(gridspec[0, 0])
+        self.ax_slit_vertical = self._fig.add_subplot(
+            gridspec[0, 1],
+            sharey=self.ax_image,
+        )
+        self.ax_slit_horizontal = self._fig.add_subplot(
+            gridspec[1, 0],
+            sharex=self.ax_image,
+        )
+        self.ax_spectrum = self._fig.add_subplot(gridspec[1, 1])
+
+        kwargs_imshow = dict(
+            origin="lower",
+            aspect="auto",
+            interpolation="nearest",
+        )
+
+        self._img_image = self.ax_image.imshow(
+            self._data_image(),
+            cmap=self._cmap_image,
+            vmin=self._vmin_image,
+            vmax=self._vmax_image,
+            **kwargs_imshow,
+        )
+        self._img_slit_vertical = self.ax_slit_vertical.imshow(
+            self._data_slit_vertical(),
+            cmap=cmap,
+            vmin=self._vmin_spectrum,
+            vmax=self._vmax_spectrum,
+            **kwargs_imshow,
+        )
+        self._img_slit_horizontal = self.ax_slit_horizontal.imshow(
+            self._data_slit_horizontal(),
+            cmap=cmap,
+            vmin=self._vmin_spectrum,
+            vmax=self._vmax_spectrum,
+            **kwargs_imshow,
+        )
+
+        kwargs_crosshair = dict(
+            color="red",
+            alpha=0.5,
+        )
+        self._crosshair_vertical = self.ax_image.axvline(
+            x=self._index_x,
+            **kwargs_crosshair,
+        )
+        self._crosshair_horizontal = self.ax_image.axhline(
+            y=self._index_y,
+            **kwargs_crosshair,
+        )
+        self._line_slit_vertical = self.ax_slit_vertical.axhline(
+            y=self._index_y,
+            **kwargs_crosshair,
+        )
+        self._line_slit_horizontal = self.ax_slit_horizontal.axvline(
+            x=self._index_x,
+            **kwargs_crosshair,
+        )
+
+        wavelength_spectrum, outputs_spectrum, mean_spectrum = self._data_spectrum()
+        (self._plot_spectrum,) = self.ax_spectrum.plot(
+            wavelength_spectrum,
+            outputs_spectrum,
+        )
+        self._line_spectrum = self.ax_spectrum.axvline(
+            x=mean_spectrum,
+            **kwargs_crosshair,
+        )
+        self.ax_spectrum.set_xlim(self._vmin_doppler, self._vmax_doppler)
+        self.ax_spectrum.set_ylim(self._vmin_spectrum, self._vmax_spectrum)
+
+        unit_wavelength = na.unit(self._wavelength.ndarray)
+        unit_outputs = na.unit(outputs.ndarray)
+        if getattr(inputs, "wavelength", None) is not None:
+            label_wavelength = self._label(axis_wavelength, unit_wavelength)
+        else:
+            label_wavelength = f"{axis_wavelength} (index)"
+
+        self.ax_image.tick_params(labelbottom=False)
+        self.ax_image.set_ylabel(f"{axis_y} (index)")
+        self.ax_slit_vertical.tick_params(labelleft=False)
+        self.ax_slit_vertical.set_xlabel(f"{axis_wavelength} (index)")
+        self.ax_slit_horizontal.set_xlabel(f"{axis_x} (index)")
+        self.ax_slit_horizontal.set_ylabel(f"{axis_wavelength} (index)")
+        self.ax_spectrum.set_xlabel(label_wavelength)
+        self.ax_spectrum.set_ylabel(self._label("outputs", unit_outputs))
+
+        self._update_title()
+
+        self._fig.canvas.mpl_connect("scroll_event", self._on_scroll)
+        self._fig.canvas.mpl_connect("key_press_event", self._on_key_press)
+        self._fig.canvas.mpl_connect("button_press_event", self._on_button_press)
+
+    @property
+    def fig(self) -> matplotlib.figure.Figure:
+        """The figure containing the four panels of the visualization."""
+        return self._fig
+
+    @property
+    def mode(self) -> str:
+        """The current display mode of the image panel."""
+        return self._mode
+
+    @property
+    def index_time(self) -> int:
+        """The index of the currently-displayed time step."""
+        return self._index_time
+
+    @property
+    def index_x(self) -> int:
+        """The horizontal index of the currently-selected point."""
+        return self._index_x
+
+    @property
+    def index_y(self) -> int:
+        """The vertical index of the currently-selected point."""
+        return self._index_y
+
+    def set_time(self, index: int) -> None:
+        """
+        Change the currently-displayed time step and update every panel.
+
+        Parameters
+        ----------
+        index
+            The new index along the time axis.
+            Wraps around using the length of the time axis.
+        """
+        self._index_time = int(index) % self._shape[self._axis_time]
+        self._update_image()
+        self._update_spectra()
+        self._fig.canvas.draw_idle()
+
+    def set_point(self, index_x: float, index_y: float) -> None:
+        """
+        Change the currently-selected spatial point and update the crosshairs
+        and the three spectral panels.
+
+        Parameters
+        ----------
+        index_x
+            The new index along the horizontal axis.
+            Rounded to the nearest integer and clipped to the valid range.
+        index_y
+            The new index along the vertical axis.
+            Rounded to the nearest integer and clipped to the valid range.
+        """
+        num_x = self._shape[self._axis_x]
+        num_y = self._shape[self._axis_y]
+        index_x = min(max(int(round(index_x)), 0), num_x - 1)
+        index_y = min(max(int(round(index_y)), 0), num_y - 1)
+        self._index_x = index_x
+        self._index_y = index_y
+        self._crosshair_vertical.set_xdata([index_x, index_x])
+        self._crosshair_horizontal.set_ydata([index_y, index_y])
+        self._line_slit_vertical.set_ydata([index_y, index_y])
+        self._line_slit_horizontal.set_xdata([index_x, index_x])
+        self._update_spectra()
+        self._fig.canvas.draw_idle()
+
+    def set_mode(self, mode: Literal["intensity", "doppler"]) -> None:
+        """
+        Change the display mode of the image panel.
+
+        Parameters
+        ----------
+        mode
+            The new display mode,
+            either ``"intensity"`` or ``"doppler"``.
+        """
+        if mode not in ("intensity", "doppler"):
+            raise ValueError(
+                f"mode must be 'intensity' or 'doppler', got {mode!r}."
+            )
+        self._mode = mode
+        self._update_image()
+        self._fig.canvas.draw_idle()
+
+    @staticmethod
+    def _label(name: str, unit: None | u.UnitBase) -> str:
+        """Format an axis label with an optional unit."""
+        if unit is not None and unit != u.dimensionless_unscaled:
+            return f"{name} ({unit})"
+        return name
+
+    @staticmethod
+    def _get_item(a: na.AbstractScalarArray, item: dict[str, int]):
+        """Index `a` using only the axes of `item` present in `a`."""
+        item = {axis: item[axis] for axis in item if axis in a.shape}
+        if item:
+            a = a[item]
+        return a
+
+    def _moment(
+        self,
+        outputs: na.AbstractScalarArray,
+        wavelength: na.AbstractScalarArray,
+    ) -> na.AbstractScalarArray:
+        """The intensity-weighted mean wavelength coordinate."""
+        axis = self._axis_wavelength
+        return (wavelength * outputs).sum(axis) / outputs.sum(axis)
+
+    @property
+    def _cmap_image(self) -> None | str | matplotlib.colors.Colormap:
+        if self._mode == "intensity":
+            return self._cmap
+        else:
+            return self._cmap_doppler
+
+    @property
+    def _vmin_image(self) -> float:
+        if self._mode == "intensity":
+            return self._vmin_intensity
+        else:
+            return self._vmin_doppler
+
+    @property
+    def _vmax_image(self) -> float:
+        if self._mode == "intensity":
+            return self._vmax_intensity
+        else:
+            return self._vmax_doppler
+
+    def _data_image(self) -> np.ndarray:
+        """The current contents of the image panel."""
+        item = {self._axis_time: self._index_time}
+        outputs = self._outputs[item]
+        if self._mode == "intensity":
+            result = outputs.sum(self._axis_wavelength)
+        else:
+            wavelength = self._get_item(self._wavelength, item)
+            result = self._moment(outputs, wavelength)
+        return result.value.ndarray_aligned((self._axis_y, self._axis_x))
+
+    def _data_slit_vertical(self) -> np.ndarray:
+        """The current contents of the vertical-slit panel."""
+        item = {
+            self._axis_time: self._index_time,
+            self._axis_x: self._index_x,
+        }
+        outputs = self._outputs[item]
+        return outputs.value.ndarray_aligned(
+            axes=(self._axis_y, self._axis_wavelength),
+        )
+
+    def _data_slit_horizontal(self) -> np.ndarray:
+        """The current contents of the horizontal-slit panel."""
+        item = {
+            self._axis_time: self._index_time,
+            self._axis_y: self._index_y,
+        }
+        outputs = self._outputs[item]
+        return outputs.value.ndarray_aligned(
+            axes=(self._axis_wavelength, self._axis_x),
+        )
+
+    def _data_spectrum(self) -> tuple[np.ndarray, np.ndarray, float]:
+        """The current contents of the single-pixel spectrum panel."""
+        item = {
+            self._axis_time: self._index_time,
+            self._axis_x: self._index_x,
+            self._axis_y: self._index_y,
+        }
+        outputs = self._outputs[item]
+        wavelength = self._get_item(self._wavelength, item)
+        mean = self._moment(outputs, wavelength)
+        axes = (self._axis_wavelength,)
+        return (
+            wavelength.value.ndarray_aligned(axes),
+            outputs.value.ndarray_aligned(axes),
+            float(mean.value.ndarray),
+        )
+
+    def _update_title(self) -> None:
+        """Update the title of the image panel."""
+        title = f"{self._mode}, {self._axis_time} = {self._index_time}"
+        if self._time is not None:
+            item = {self._axis_time: self._index_time}
+            time = self._get_item(self._time, item)
+            if time.shape:
+                time = time.mean()
+            title = f"{title} ({time.ndarray})"
+        self.ax_image.set_title(title)
+
+    def _update_image(self) -> None:
+        """Update the image panel to reflect the current state."""
+        self._img_image.set_data(self._data_image())
+        self._img_image.set_cmap(self._cmap_image)
+        self._img_image.set_clim(self._vmin_image, self._vmax_image)
+        self._update_title()
+
+    def _update_spectra(self) -> None:
+        """Update the three spectral panels to reflect the current state."""
+        self._img_slit_vertical.set_data(self._data_slit_vertical())
+        self._img_slit_horizontal.set_data(self._data_slit_horizontal())
+        wavelength, outputs, mean = self._data_spectrum()
+        self._plot_spectrum.set_data(wavelength, outputs)
+        self._line_spectrum.set_xdata([mean, mean])
+
+    def _on_scroll(self, event: matplotlib.backend_bases.MouseEvent) -> None:
+        """Step through the time axis using the mouse scroll wheel."""
+        if event.button == "up":
+            self.set_time(self._index_time + 1)
+        elif event.button == "down":
+            self.set_time(self._index_time - 1)
+
+    def _on_key_press(self, event: matplotlib.backend_bases.KeyEvent) -> None:
+        """Step through time or toggle the mode using the keyboard."""
+        if event.key == "right":
+            self.set_time(self._index_time + 1)
+        elif event.key == "left":
+            self.set_time(self._index_time - 1)
+        elif event.key == "m":
+            if self._mode == "intensity":
+                self.set_mode("doppler")
+            else:
+                self.set_mode("intensity")
+
+    def _on_button_press(
+        self,
+        event: matplotlib.backend_bases.MouseEvent,
+    ) -> None:
+        """Select a new spatial point by clicking on the image panel."""
+        if event.inaxes is self.ax_image:
+            if event.xdata is not None and event.ydata is not None:
+                self.set_point(event.xdata, event.ydata)

--- a/named_arrays/plt.py
+++ b/named_arrays/plt.py
@@ -2504,22 +2504,38 @@ class HypercubeSlicer:
     The data to visualize is an instance of
     :class:`named_arrays.FunctionArray` whose ``outputs`` has a temporal,
     a spectral, and two spatial logical axes.
-    The figure is a 2 :math:`\\times` 2 mosaic of four panels:
+    The figure is a 2 :math:`\\times` 2 mosaic of four panels,
+    with colorbars in dedicated slots of the grid:
 
     - The `image` panel (upper left, largest) displays the current time step,
       either integrated over the wavelength axis (``"intensity"`` mode)
       or as the intensity-weighted mean wavelength coordinate
       (``"doppler"`` mode).
-      Crosshairs mark the currently-selected spatial point.
+      Crosshairs mark the currently-selected spatial point,
+      and the panel's colorbar updates with the mode.
     - The `vertical slit` panel (upper right) displays wavelength (horizontal)
       vs. vertical position for the selected column of the image,
       the spectrum a spectrograph with a vertical slit through the selected
       point would measure.
     - The `horizontal slit` panel (lower left) displays horizontal position
       vs. wavelength (vertical) for the selected row of the image.
+      It shares a norm and a colorbar with the vertical slit panel since they
+      display the same physical quantity.
     - The `spectrum` panel (lower right) displays the spectrum of the single
       selected pixel, with a vertical line marking its mean wavelength
       coordinate.
+
+    Every color scale is global and data-derived, computed once at
+    construction from percentiles over `all` time steps, so nothing rescales
+    or clips while stepping through time or selecting new points:
+    the intensity norm comes from the wavelength-integrated intensity,
+    the shared slit norm from the full 4-dimensional cube,
+    and the Doppler norm is symmetric about the global intensity-weighted
+    mean wavelength coordinate with a half-range given by a high percentile
+    of the per-pixel first-moment deviation from that center.
+    The vertical limits of the spectrum panel span the extrema over time of
+    the selected pixel's spectra, and are only recomputed when a new point
+    is selected.
 
     The viewer is interactive:
     left-clicking anywhere on the image panel selects a new spatial point,
@@ -2567,10 +2583,11 @@ class HypercubeSlicer:
     cmap_doppler
         The colormap used by the image panel in ``"doppler"`` mode.
     percentile
-        The lower and upper percentiles of the data used to compute the
+        The lower and upper percentiles of the data used to compute every
         color scale.
     width_ratios
-        The relative widths of the left and right columns of the figure.
+        The relative widths of the left and right panel columns of the
+        figure.
     height_ratios
         The relative heights of the upper and lower rows of the figure.
     kwargs_figure
@@ -2700,39 +2717,87 @@ class HypercubeSlicer:
         self._cmap = cmap
         self._cmap_doppler = cmap_doppler
 
+        # Global, data-derived color scales, computed once at construction so
+        # that no panel ever rescales while scrolling through time or
+        # selecting new points.
         intensity = outputs.sum(axis_wavelength).value.ndarray
-        self._vmin_intensity, self._vmax_intensity = np.nanpercentile(
-            intensity,
-            percentile,
+        vmin_intensity, vmax_intensity = np.nanpercentile(intensity, percentile)
+        self._norm_intensity = matplotlib.colors.Normalize(
+            vmin=vmin_intensity,
+            vmax=vmax_intensity,
         )
-        self._vmin_spectrum, self._vmax_spectrum = np.nanpercentile(
+
+        # The two slit panels display the same physical quantity, so they
+        # share a single norm derived from the full 4-dimensional cube.
+        vmin_spectrum, vmax_spectrum = np.nanpercentile(
             outputs.value.ndarray,
             percentile,
         )
-        wavelength_ndarray = wavelength.value.ndarray
-        self._vmin_doppler = np.nanmin(wavelength_ndarray)
-        self._vmax_doppler = np.nanmax(wavelength_ndarray)
+        self._norm_spectrum = matplotlib.colors.Normalize(
+            vmin=vmin_spectrum,
+            vmax=vmax_spectrum,
+        )
 
-        kwargs_figure.setdefault("figsize", (10, 8))
+        wavelength_ndarray = wavelength.value.ndarray
+        self._wavelength_min = np.nanmin(wavelength_ndarray)
+        self._wavelength_max = np.nanmax(wavelength_ndarray)
+
+        # The Doppler scale is a symmetric norm centered on the global
+        # intensity-weighted mean wavelength coordinate, with half-range
+        # given by a high percentile of the deviation of the per-pixel first
+        # moment from that center over all times.
+        center = (wavelength * outputs).sum() / outputs.sum()
+        deviation = np.abs(self._moment(outputs, wavelength) - center)
+        center = float(center.value.ndarray)
+        halfrange = float(
+            np.nanpercentile(deviation.value.ndarray, percentile[~0]),
+        )
+        if not halfrange > 0:
+            halfrange = max(
+                center - self._wavelength_min,
+                self._wavelength_max - center,
+                1,
+            )
+        self._norm_doppler = matplotlib.colors.Normalize(
+            vmin=center - halfrange,
+            vmax=center + halfrange,
+        )
+
+        unit_wavelength = na.unit(wavelength.ndarray)
+        unit_outputs = na.unit(outputs.ndarray)
+        if getattr(inputs, "wavelength", None) is not None:
+            self._label_wavelength = self._label(axis_wavelength, unit_wavelength)
+        else:
+            self._label_wavelength = f"{axis_wavelength} (index)"
+        self._label_intensity = self._label("intensity", unit_outputs)
+        self._label_outputs = self._label("outputs", unit_outputs)
+
+        kwargs_figure.setdefault("figsize", (11, 8))
         kwargs_figure.setdefault("constrained_layout", True)
         self._fig = plt.figure(**kwargs_figure)
 
+        # The colorbars live in explicit thin columns of the gridspec so that
+        # the panel layout is deterministic and does not reflow when the mode
+        # is toggled.
+        width_cax = 0.05 * sum(width_ratios)
         gridspec = self._fig.add_gridspec(
             nrows=2,
-            ncols=2,
-            width_ratios=width_ratios,
+            ncols=4,
+            width_ratios=(width_ratios[0], width_cax, width_ratios[1], width_cax),
             height_ratios=height_ratios,
         )
         self.ax_image = self._fig.add_subplot(gridspec[0, 0])
+        self.cax_image = self._fig.add_subplot(gridspec[0, 1])
         self.ax_slit_vertical = self._fig.add_subplot(
-            gridspec[0, 1],
+            gridspec[0, 2],
             sharey=self.ax_image,
         )
+        self.cax_slit = self._fig.add_subplot(gridspec[0, 3])
         self.ax_slit_horizontal = self._fig.add_subplot(
             gridspec[1, 0],
             sharex=self.ax_image,
         )
-        self.ax_spectrum = self._fig.add_subplot(gridspec[1, 1])
+        self.ax_spectrum = self._fig.add_subplot(gridspec[1, 2:])
 
         kwargs_imshow = dict(
             origin="lower",
@@ -2743,24 +2808,32 @@ class HypercubeSlicer:
         self._img_image = self.ax_image.imshow(
             self._data_image(),
             cmap=self._cmap_image,
-            vmin=self._vmin_image,
-            vmax=self._vmax_image,
+            norm=self._norm_image,
             **kwargs_imshow,
         )
         self._img_slit_vertical = self.ax_slit_vertical.imshow(
             self._data_slit_vertical(),
             cmap=cmap,
-            vmin=self._vmin_spectrum,
-            vmax=self._vmax_spectrum,
+            norm=self._norm_spectrum,
             **kwargs_imshow,
         )
         self._img_slit_horizontal = self.ax_slit_horizontal.imshow(
             self._data_slit_horizontal(),
             cmap=cmap,
-            vmin=self._vmin_spectrum,
-            vmax=self._vmax_spectrum,
+            norm=self._norm_spectrum,
             **kwargs_imshow,
         )
+
+        self._colorbar_image = self._fig.colorbar(
+            self._img_image,
+            cax=self.cax_image,
+        )
+        self._colorbar_image.set_label(self._label_colorbar_image)
+        self._colorbar_slit = self._fig.colorbar(
+            self._img_slit_vertical,
+            cax=self.cax_slit,
+        )
+        self._colorbar_slit.set_label(self._label_outputs)
 
         kwargs_crosshair = dict(
             color="red",
@@ -2792,15 +2865,8 @@ class HypercubeSlicer:
             x=mean_spectrum,
             **kwargs_crosshair,
         )
-        self.ax_spectrum.set_xlim(self._vmin_doppler, self._vmax_doppler)
-        self.ax_spectrum.set_ylim(self._vmin_spectrum, self._vmax_spectrum)
-
-        unit_wavelength = na.unit(self._wavelength.ndarray)
-        unit_outputs = na.unit(outputs.ndarray)
-        if getattr(inputs, "wavelength", None) is not None:
-            label_wavelength = self._label(axis_wavelength, unit_wavelength)
-        else:
-            label_wavelength = f"{axis_wavelength} (index)"
+        self.ax_spectrum.set_xlim(self._wavelength_min, self._wavelength_max)
+        self._update_spectrum_ylim()
 
         self.ax_image.tick_params(labelbottom=False)
         self.ax_image.set_ylabel(f"{axis_y} (index)")
@@ -2808,8 +2874,8 @@ class HypercubeSlicer:
         self.ax_slit_vertical.set_xlabel(f"{axis_wavelength} (index)")
         self.ax_slit_horizontal.set_xlabel(f"{axis_x} (index)")
         self.ax_slit_horizontal.set_ylabel(f"{axis_wavelength} (index)")
-        self.ax_spectrum.set_xlabel(label_wavelength)
-        self.ax_spectrum.set_ylabel(self._label("outputs", unit_outputs))
+        self.ax_spectrum.set_xlabel(self._label_wavelength)
+        self.ax_spectrum.set_ylabel(self._label_outputs)
 
         self._update_title()
 
@@ -2882,6 +2948,7 @@ class HypercubeSlicer:
         self._line_slit_vertical.set_ydata([index_y, index_y])
         self._line_slit_horizontal.set_xdata([index_x, index_x])
         self._update_spectra()
+        self._update_spectrum_ylim()
         self._fig.canvas.draw_idle()
 
     def set_mode(self, mode: Literal["intensity", "doppler"]) -> None:
@@ -2934,18 +3001,18 @@ class HypercubeSlicer:
             return self._cmap_doppler
 
     @property
-    def _vmin_image(self) -> float:
+    def _norm_image(self) -> matplotlib.colors.Normalize:
         if self._mode == "intensity":
-            return self._vmin_intensity
+            return self._norm_intensity
         else:
-            return self._vmin_doppler
+            return self._norm_doppler
 
     @property
-    def _vmax_image(self) -> float:
+    def _label_colorbar_image(self) -> str:
         if self._mode == "intensity":
-            return self._vmax_intensity
+            return self._label_intensity
         else:
-            return self._vmax_doppler
+            return self._label_wavelength
 
     def _data_image(self) -> np.ndarray:
         """The current contents of the image panel."""
@@ -3012,8 +3079,32 @@ class HypercubeSlicer:
         """Update the image panel to reflect the current state."""
         self._img_image.set_data(self._data_image())
         self._img_image.set_cmap(self._cmap_image)
-        self._img_image.set_clim(self._vmin_image, self._vmax_image)
+        self._img_image.set_norm(self._norm_image)
+        self._colorbar_image.set_label(self._label_colorbar_image)
         self._update_title()
+
+    def _update_spectrum_ylim(self) -> None:
+        """
+        Update the vertical limits of the single-pixel spectrum panel.
+
+        The limits are computed from the extrema over `every` time step of
+        the spectrum of the currently-selected point, so that stepping
+        through time shows the true amplitude evolution without clipping or
+        rescaling.
+        """
+        item = {
+            self._axis_x: self._index_x,
+            self._axis_y: self._index_y,
+        }
+        spectra = self._outputs[item].value.ndarray
+        lo = float(np.nanmin(spectra))
+        hi = float(np.nanmax(spectra))
+        if not np.isfinite(lo) or not np.isfinite(hi):
+            return
+        pad = 0.1 * (hi - lo)
+        if not pad > 0:
+            pad = max(0.1 * abs(hi), 1)
+        self.ax_spectrum.set_ylim(lo - pad, hi + pad)
 
     def _update_spectra(self) -> None:
         """Update the three spectral panels to reflect the current state."""

--- a/named_arrays/tests/test_plt.py
+++ b/named_arrays/tests/test_plt.py
@@ -3,6 +3,7 @@ import numpy as np
 import matplotlib.axes
 import matplotlib.animation
 import matplotlib.text
+import matplotlib.backend_bases
 import matplotlib.pyplot as plt
 import astropy.units as u
 import named_arrays as na
@@ -704,3 +705,304 @@ def test_invert_yaxis(
     ax: None | matplotlib.axes.Axes | na.AbstractScalar,
 ):
     na.plt.invert_yaxis(ax)
+
+
+_num_slicer_t = 3
+_num_slicer_w = 5
+_num_slicer_x = 8
+_num_slicer_y = 7
+
+_kwargs_slicer = dict(
+    axis_time="t",
+    axis_wavelength="w",
+    axis_x="x",
+    axis_y="y",
+)
+
+
+def _hypercube_function(units: bool) -> na.FunctionArray:
+    """A moving Gaussian blob with a spatially-varying Doppler shift."""
+    time = na.linspace(0, 2, axis="t", num=_num_slicer_t)
+    wavelength = na.linspace(-2, 2, axis="w", num=_num_slicer_w)
+    x = na.linspace(-1, 1, axis="x", num=_num_slicer_x)
+    y = na.linspace(-1, 1, axis="y", num=_num_slicer_y)
+
+    center = 0.5 * time - 0.5
+    blob = np.exp(-(np.square(x - center) + np.square(y)) / np.square(0.5))
+    line = np.exp(-np.square(wavelength - x) / 2)
+    outputs = 1 + blob * line
+
+    if units:
+        time = time * u.s
+        wavelength = 500 * u.nm + wavelength * u.nm
+        outputs = outputs * u.photon
+
+    return na.FunctionArray(
+        inputs=na.TemporalSpectralPositionalVectorArray(
+            time=time,
+            wavelength=wavelength,
+            position=na.Cartesian2dVectorArray(x, y),
+        ),
+        outputs=outputs,
+    )
+
+
+def _hypercube_wavelength(function: na.FunctionArray) -> na.AbstractScalar:
+    return na.as_named_array(function.inputs.wavelength).broadcast_to(
+        shape={"w": _num_slicer_w},
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="function",
+    argvalues=[
+        _hypercube_function(units=False),
+        _hypercube_function(units=True),
+    ],
+)
+def test_hypercube_slicer(function: na.FunctionArray):
+    slicer = na.plt.HypercubeSlicer(function, **_kwargs_slicer)
+
+    assert isinstance(slicer.fig, plt.Figure)
+    assert slicer.mode == "intensity"
+    assert slicer.index_time == 0
+    assert slicer.index_x == _num_slicer_x // 2
+    assert slicer.index_y == _num_slicer_y // 2
+
+    result = slicer.ax_image.images[0].get_array()
+    expected = function.outputs[dict(t=0)].sum("w")
+    expected = expected.value.ndarray_aligned(("y", "x"))
+    assert result.shape == (_num_slicer_y, _num_slicer_x)
+    np.testing.assert_allclose(result, expected)
+
+    plt.close(slicer.fig)
+
+
+@pytest.mark.parametrize(
+    argnames="function",
+    argvalues=[
+        _hypercube_function(units=False),
+        _hypercube_function(units=True),
+    ],
+)
+def test_hypercube_slicer_set_time(function: na.FunctionArray):
+    slicer = na.plt.HypercubeSlicer(function, **_kwargs_slicer)
+
+    slicer.set_time(1)
+    assert slicer.index_time == 1
+
+    result = slicer.ax_image.images[0].get_array()
+    expected = function.outputs[dict(t=1)].sum("w")
+    expected = expected.value.ndarray_aligned(("y", "x"))
+    np.testing.assert_allclose(result, expected)
+
+    result_slit = slicer.ax_slit_vertical.images[0].get_array()
+    expected_slit = function.outputs[dict(t=1, x=slicer.index_x)]
+    expected_slit = expected_slit.value.ndarray_aligned(("y", "w"))
+    np.testing.assert_allclose(result_slit, expected_slit)
+
+    slicer.set_time(_num_slicer_t)
+    assert slicer.index_time == 0
+
+    slicer.set_time(-1)
+    assert slicer.index_time == _num_slicer_t - 1
+
+    plt.close(slicer.fig)
+
+
+@pytest.mark.parametrize(
+    argnames="function",
+    argvalues=[
+        _hypercube_function(units=False),
+        _hypercube_function(units=True),
+    ],
+)
+def test_hypercube_slicer_set_point(function: na.FunctionArray):
+    slicer = na.plt.HypercubeSlicer(function, **_kwargs_slicer)
+
+    index_x = 2
+    index_y = 3
+    slicer.set_point(index_x, index_y)
+    assert slicer.index_x == index_x
+    assert slicer.index_y == index_y
+
+    outputs = function.outputs
+
+    result_vertical = slicer.ax_slit_vertical.images[0].get_array()
+    expected_vertical = outputs[dict(t=0, x=index_x)]
+    expected_vertical = expected_vertical.value.ndarray_aligned(("y", "w"))
+    assert result_vertical.shape == (_num_slicer_y, _num_slicer_w)
+    np.testing.assert_allclose(result_vertical, expected_vertical)
+
+    result_horizontal = slicer.ax_slit_horizontal.images[0].get_array()
+    expected_horizontal = outputs[dict(t=0, y=index_y)]
+    expected_horizontal = expected_horizontal.value.ndarray_aligned(("w", "x"))
+    assert result_horizontal.shape == (_num_slicer_w, _num_slicer_x)
+    np.testing.assert_allclose(result_horizontal, expected_horizontal)
+
+    spectrum = outputs[dict(t=0, x=index_x, y=index_y)]
+    wavelength = _hypercube_wavelength(function)
+    line = slicer.ax_spectrum.lines[0]
+    np.testing.assert_allclose(
+        line.get_xdata(),
+        wavelength.value.ndarray_aligned(("w",)),
+    )
+    np.testing.assert_allclose(
+        line.get_ydata(),
+        spectrum.value.ndarray_aligned(("w",)),
+    )
+
+    expected_mean = (wavelength * spectrum).sum("w") / spectrum.sum("w")
+    result_mean = slicer._line_spectrum.get_xdata()[0]
+    np.testing.assert_allclose(result_mean, expected_mean.value.ndarray)
+
+    crosshair_x = slicer._crosshair_vertical.get_xdata()[0]
+    crosshair_y = slicer._crosshair_horizontal.get_ydata()[0]
+    assert crosshair_x == index_x
+    assert crosshair_y == index_y
+
+    slicer.set_point(-100, 100)
+    assert slicer.index_x == 0
+    assert slicer.index_y == _num_slicer_y - 1
+
+    plt.close(slicer.fig)
+
+
+@pytest.mark.parametrize(
+    argnames="function",
+    argvalues=[
+        _hypercube_function(units=False),
+        _hypercube_function(units=True),
+    ],
+)
+def test_hypercube_slicer_set_mode(function: na.FunctionArray):
+    slicer = na.plt.HypercubeSlicer(function, **_kwargs_slicer)
+
+    slicer.set_mode("doppler")
+    assert slicer.mode == "doppler"
+
+    outputs = function.outputs[dict(t=0)]
+    wavelength = _hypercube_wavelength(function)
+    expected = (wavelength * outputs).sum("w") / outputs.sum("w")
+    expected = expected.value.ndarray_aligned(("y", "x"))
+
+    result = slicer.ax_image.images[0].get_array()
+    np.testing.assert_allclose(result, expected)
+
+    slicer.set_mode("intensity")
+    assert slicer.mode == "intensity"
+
+    result = slicer.ax_image.images[0].get_array()
+    expected = function.outputs[dict(t=0)].sum("w")
+    expected = expected.value.ndarray_aligned(("y", "x"))
+    np.testing.assert_allclose(result, expected)
+
+    with pytest.raises(ValueError):
+        slicer.set_mode("invalid")
+
+    plt.close(slicer.fig)
+
+
+def test_hypercube_slicer_wavelength_index():
+    function = _hypercube_function(units=False)
+    function = na.FunctionArray(
+        inputs=function.inputs.position,
+        outputs=function.outputs,
+    )
+    slicer = na.plt.HypercubeSlicer(function, **_kwargs_slicer)
+
+    slicer.set_mode("doppler")
+
+    outputs = function.outputs[dict(t=0)]
+    wavelength = na.ScalarArray(np.arange(_num_slicer_w), axes=("w",))
+    expected = (wavelength * outputs).sum("w") / outputs.sum("w")
+    expected = expected.value.ndarray_aligned(("y", "x"))
+
+    result = slicer.ax_image.images[0].get_array()
+    np.testing.assert_allclose(result, expected)
+
+    plt.close(slicer.fig)
+
+
+def test_hypercube_slicer_invalid_axis():
+    function = _hypercube_function(units=False)
+    with pytest.raises(ValueError):
+        na.plt.HypercubeSlicer(function, axis_time="invalid")
+
+
+def test_hypercube_slicer_invalid_mode():
+    function = _hypercube_function(units=False)
+    with pytest.raises(ValueError):
+        na.plt.HypercubeSlicer(function, **_kwargs_slicer, mode="invalid")
+
+
+def test_hypercube_slicer_events():
+    function = _hypercube_function(units=True)
+    slicer = na.plt.HypercubeSlicer(function, **_kwargs_slicer)
+    fig = slicer.fig
+    fig.canvas.draw()
+
+    event_scroll = matplotlib.backend_bases.MouseEvent(
+        name="scroll_event",
+        canvas=fig.canvas,
+        x=0,
+        y=0,
+        button="up",
+    )
+    fig.canvas.callbacks.process("scroll_event", event_scroll)
+    assert slicer.index_time == 1
+
+    event_scroll_down = matplotlib.backend_bases.MouseEvent(
+        name="scroll_event",
+        canvas=fig.canvas,
+        x=0,
+        y=0,
+        button="down",
+    )
+    fig.canvas.callbacks.process("scroll_event", event_scroll_down)
+    assert slicer.index_time == 0
+
+    event_key_right = matplotlib.backend_bases.KeyEvent(
+        name="key_press_event",
+        canvas=fig.canvas,
+        key="right",
+    )
+    fig.canvas.callbacks.process("key_press_event", event_key_right)
+    assert slicer.index_time == 1
+
+    event_key_left = matplotlib.backend_bases.KeyEvent(
+        name="key_press_event",
+        canvas=fig.canvas,
+        key="left",
+    )
+    fig.canvas.callbacks.process("key_press_event", event_key_left)
+    assert slicer.index_time == 0
+
+    event_key_m = matplotlib.backend_bases.KeyEvent(
+        name="key_press_event",
+        canvas=fig.canvas,
+        key="m",
+    )
+    fig.canvas.callbacks.process("key_press_event", event_key_m)
+    assert slicer.mode == "doppler"
+
+    fig.canvas.callbacks.process("key_press_event", event_key_m)
+    assert slicer.mode == "intensity"
+
+    index_x = 4
+    index_y = 2
+    x_display, y_display = slicer.ax_image.transData.transform(
+        (index_x, index_y),
+    )
+    event_click = matplotlib.backend_bases.MouseEvent(
+        name="button_press_event",
+        canvas=fig.canvas,
+        x=x_display,
+        y=y_display,
+        button=matplotlib.backend_bases.MouseButton.LEFT,
+    )
+    fig.canvas.callbacks.process("button_press_event", event_click)
+    assert slicer.index_x == index_x
+    assert slicer.index_y == index_y
+
+    plt.close(fig)

--- a/named_arrays/tests/test_plt.py
+++ b/named_arrays/tests/test_plt.py
@@ -734,7 +734,7 @@ def _hypercube_function(units: bool) -> na.FunctionArray:
 
     if units:
         time = time * u.s
-        wavelength = 500 * u.nm + wavelength * u.nm
+        wavelength = 500 * u.nm + wavelength * (2 * u.nm)
         outputs = outputs * u.photon
 
     return na.FunctionArray(
@@ -751,6 +751,12 @@ def _hypercube_wavelength(function: na.FunctionArray) -> na.AbstractScalar:
     return na.as_named_array(function.inputs.wavelength).broadcast_to(
         shape={"w": _num_slicer_w},
     )
+
+
+def _hypercube_dwavelength(function: na.FunctionArray) -> float:
+    """The mean cell width of the wavelength coordinate."""
+    wavelength = _hypercube_wavelength(function)
+    return float(np.mean(np.abs(np.diff(wavelength.value.ndarray))))
 
 
 @pytest.mark.parametrize(
@@ -771,7 +777,8 @@ def test_hypercube_slicer(function: na.FunctionArray):
 
     result = slicer.ax_image.images[0].get_array()
     expected = function.outputs[dict(t=0)].sum("w")
-    expected = expected.value.ndarray_aligned(("y", "x"))
+    expected = _hypercube_dwavelength(function) * expected.value
+    expected = expected.ndarray_aligned(("y", "x"))
     assert result.shape == (_num_slicer_y, _num_slicer_x)
     np.testing.assert_allclose(result, expected)
 
@@ -793,7 +800,8 @@ def test_hypercube_slicer_set_time(function: na.FunctionArray):
 
     result = slicer.ax_image.images[0].get_array()
     expected = function.outputs[dict(t=1)].sum("w")
-    expected = expected.value.ndarray_aligned(("y", "x"))
+    expected = _hypercube_dwavelength(function) * expected.value
+    expected = expected.ndarray_aligned(("y", "x"))
     np.testing.assert_allclose(result, expected)
 
     result_slit = slicer.ax_slit_vertical.images[0].get_array()
@@ -894,7 +902,8 @@ def test_hypercube_slicer_set_mode(function: na.FunctionArray):
 
     result = slicer.ax_image.images[0].get_array()
     expected = function.outputs[dict(t=0)].sum("w")
-    expected = expected.value.ndarray_aligned(("y", "x"))
+    expected = _hypercube_dwavelength(function) * expected.value
+    expected = expected.ndarray_aligned(("y", "x"))
     np.testing.assert_allclose(result, expected)
 
     with pytest.raises(ValueError):
@@ -1026,7 +1035,7 @@ def test_hypercube_slicer_norm_fixed(function: na.FunctionArray):
     ylim_spectrum = slicer.ax_spectrum.get_ylim()
 
     expected_image = np.nanpercentile(
-        outputs.sum("w").value.ndarray,
+        _hypercube_dwavelength(function) * outputs.sum("w").value.ndarray,
         (0.1, 99.9),
     )
     np.testing.assert_allclose(clim_image, expected_image)
@@ -1117,3 +1126,52 @@ def test_hypercube_slicer_colorbar(function: na.FunctionArray):
     )
 
     plt.close(fig)
+
+
+def test_hypercube_slicer_labels():
+    """Labels must follow the caller's axis names and the coordinate units."""
+    time = na.linspace(0, 2, axis="t", num=_num_slicer_t) * u.s
+    velocity = na.linspace(-100, 100, axis="velocity", num=_num_slicer_w)
+    velocity = velocity * (u.km / u.s)
+    sky_x = na.linspace(-1, 1, axis="sky_x", num=_num_slicer_x) * u.arcsec
+    sky_y = na.linspace(-1, 1, axis="sky_y", num=_num_slicer_y) * u.arcsec
+
+    outputs = np.exp(-np.square(velocity / (50 * u.km / u.s)))
+    outputs = outputs * np.exp(-np.square(sky_x / u.arcsec))
+    outputs = outputs * np.exp(-np.square(sky_y / u.arcsec))
+    outputs = (1 + 0 * time / u.s) * outputs * u.ph
+
+    function = na.FunctionArray(
+        inputs=na.TemporalSpectralPositionalVectorArray(
+            time=time,
+            wavelength=velocity,
+            position=na.Cartesian2dVectorArray(sky_x, sky_y),
+        ),
+        outputs=outputs,
+    )
+
+    slicer = na.plt.HypercubeSlicer(
+        function,
+        axis_time="t",
+        axis_wavelength="velocity",
+        axis_x="sky_x",
+        axis_y="sky_y",
+    )
+
+    unit_velocity = u.km / u.s
+
+    assert slicer.ax_image.get_ylabel() == "sky_y (index)"
+    assert slicer.ax_slit_vertical.get_xlabel() == "velocity (index)"
+    assert slicer.ax_slit_horizontal.get_xlabel() == "sky_x (index)"
+    assert slicer.ax_slit_horizontal.get_ylabel() == "velocity (index)"
+    assert slicer.ax_spectrum.get_xlabel() == f"velocity ({unit_velocity})"
+    assert slicer.ax_spectrum.get_ylabel() == f"outputs ({u.ph})"
+    assert "t = 0" in slicer.ax_image.get_title()
+
+    assert slicer.cax_slit.get_ylabel() == f"outputs ({u.ph})"
+    assert slicer.cax_image.get_ylabel() == f"intensity ({u.ph * unit_velocity})"
+
+    slicer.set_mode("doppler")
+    assert slicer.cax_image.get_ylabel() == f"mean velocity ({unit_velocity})"
+
+    plt.close(slicer.fig)

--- a/named_arrays/tests/test_plt.py
+++ b/named_arrays/tests/test_plt.py
@@ -1006,3 +1006,114 @@ def test_hypercube_slicer_events():
     assert slicer.index_y == index_y
 
     plt.close(fig)
+
+
+@pytest.mark.parametrize(
+    argnames="function",
+    argvalues=[
+        _hypercube_function(units=False),
+        _hypercube_function(units=True),
+    ],
+)
+def test_hypercube_slicer_norm_fixed(function: na.FunctionArray):
+    slicer = na.plt.HypercubeSlicer(function, **_kwargs_slicer)
+
+    outputs = function.outputs
+
+    clim_image = slicer.ax_image.images[0].get_clim()
+    clim_vertical = slicer.ax_slit_vertical.images[0].get_clim()
+    clim_horizontal = slicer.ax_slit_horizontal.images[0].get_clim()
+    ylim_spectrum = slicer.ax_spectrum.get_ylim()
+
+    expected_image = np.nanpercentile(
+        outputs.sum("w").value.ndarray,
+        (0.1, 99.9),
+    )
+    np.testing.assert_allclose(clim_image, expected_image)
+
+    expected_slit = np.nanpercentile(outputs.value.ndarray, (0.1, 99.9))
+    np.testing.assert_allclose(clim_vertical, expected_slit)
+    assert clim_vertical == clim_horizontal
+
+    # stepping through time must not change any color scale or the
+    # vertical limits of the spectrum panel
+    slicer.set_time(1)
+    assert slicer.ax_image.images[0].get_clim() == clim_image
+    assert slicer.ax_slit_vertical.images[0].get_clim() == clim_vertical
+    assert slicer.ax_slit_horizontal.images[0].get_clim() == clim_horizontal
+    assert slicer.ax_spectrum.get_ylim() == ylim_spectrum
+
+    # selecting a new point must not change any color scale, but must
+    # recompute the vertical limits of the spectrum panel from the extrema
+    # over time of the new point's spectra
+    index_x = 0
+    index_y = 0
+    slicer.set_point(index_x, index_y)
+    assert slicer.ax_image.images[0].get_clim() == clim_image
+    assert slicer.ax_slit_vertical.images[0].get_clim() == clim_vertical
+
+    spectra = outputs[dict(x=index_x, y=index_y)].value.ndarray
+    lo = spectra.min()
+    hi = spectra.max()
+    pad = 0.1 * (hi - lo)
+    np.testing.assert_allclose(
+        slicer.ax_spectrum.get_ylim(),
+        (lo - pad, hi + pad),
+    )
+
+    plt.close(slicer.fig)
+
+
+@pytest.mark.parametrize(
+    argnames="function",
+    argvalues=[
+        _hypercube_function(units=False),
+        _hypercube_function(units=True),
+    ],
+)
+def test_hypercube_slicer_colorbar(function: na.FunctionArray):
+    slicer = na.plt.HypercubeSlicer(function, **_kwargs_slicer)
+    fig = slicer.fig
+
+    # four panels plus two colorbar axes
+    assert len(fig.axes) == 6
+
+    label_intensity = slicer.cax_image.get_ylabel()
+
+    num_axes = len(fig.axes)
+    num_children = len(fig.get_children())
+    for _ in range(5):
+        slicer.set_mode("doppler")
+        slicer.set_mode("intensity")
+    assert len(fig.axes) == num_axes
+    assert len(fig.get_children()) == num_children
+    assert slicer.cax_image.get_ylabel() == label_intensity
+
+    # the colorbar of the image panel must track the norm, colormap, and
+    # label of the current mode
+    slicer.set_mode("doppler")
+    fig.canvas.draw()
+    assert slicer.cax_image.get_ylabel() != label_intensity
+
+    outputs = function.outputs
+    wavelength = _hypercube_wavelength(function)
+    center = (wavelength * outputs).sum() / outputs.sum()
+    moment = (wavelength * outputs).sum("w") / outputs.sum("w")
+    deviation = np.abs(moment - center).value.ndarray
+    center = float(center.value.ndarray)
+    halfrange = float(np.nanpercentile(deviation, 99.9))
+
+    clim = slicer.ax_image.images[0].get_clim()
+    np.testing.assert_allclose(clim, (center - halfrange, center + halfrange))
+    np.testing.assert_allclose(
+        slicer._colorbar_image.mappable.get_clim(),
+        clim,
+    )
+
+    # the shared slit colorbar reflects the norm of both slit panels
+    np.testing.assert_allclose(
+        slicer._colorbar_slit.mappable.get_clim(),
+        slicer.ax_slit_horizontal.images[0].get_clim(),
+    )
+
+    plt.close(fig)

--- a/named_arrays/tests/test_plt.py
+++ b/named_arrays/tests/test_plt.py
@@ -1175,3 +1175,43 @@ def test_hypercube_slicer_labels():
     assert slicer.cax_image.get_ylabel() == f"mean velocity ({unit_velocity})"
 
     plt.close(slicer.fig)
+
+
+def test_hypercube_slicer_extend():
+    """Colorbars must advertise when their norm clips the data range."""
+    # A cube of exact integers with a moment-balanced spectral profile has
+    # an exactly-zero first moment everywhere, which lies strictly inside the
+    # symmetric doppler norm, while its wavelength-integrated intensity (and
+    # its outputs) are spread widely enough that the percentile norms clip
+    # at both ends.
+    time = na.ScalarArray(np.arange(_num_slicer_t, dtype=float), axes=("t",))
+    wavelength = na.linspace(-2, 2, axis="w", num=_num_slicer_w)
+    x = na.ScalarArray(np.arange(_num_slicer_x, dtype=float), axes=("x",))
+    y = na.ScalarArray(np.arange(_num_slicer_y, dtype=float), axes=("y",))
+    # spectral weights with distinct values chosen so the first moment over
+    # the wavelength grid [-2, -1, 0, 1, 2] is exactly zero in integer
+    # arithmetic: -2*1 - 1*6 + 0*3 + 1*4 + 2*2 = 0
+    weights = na.ScalarArray(np.array([1.0, 6.0, 3.0, 4.0, 2.0]), axes=("w",))
+    outputs = (1 + 100 * time + 10 * x + y) * weights
+
+    function_flat = na.FunctionArray(
+        inputs=na.TemporalSpectralPositionalVectorArray(
+            time=time,
+            wavelength=wavelength,
+            position=na.Cartesian2dVectorArray(x, y),
+        ),
+        outputs=outputs,
+    )
+    slicer_flat = na.plt.HypercubeSlicer(function_flat, **_kwargs_slicer)
+
+    assert slicer_flat._colorbar_image.extend == "both"
+    assert slicer_flat._colorbar_slit.extend == "both"
+
+    slicer_flat.set_mode("doppler")
+    assert slicer_flat._colorbar_image.extend == "neither"
+
+    # the extend decision must be re-evaluated on every mode switch
+    slicer_flat.set_mode("intensity")
+    assert slicer_flat._colorbar_image.extend == "both"
+
+    plt.close(slicer_flat.fig)


### PR DESCRIPTION
## Summary

Adds `na.plt.HypercubeSlicer`, an interactive matplotlib viewer for 4D spectral cubes (`time × x × y × wavelength/velocity`), built for browsing time-dependent spectral reconstructions (e.g. CTIS inversions) but generic over any `FunctionArray` with those axes.

- Scroll / arrow keys step through time; clicking the image moves a crosshair that drives a spectrum panel at that spatial point; `m` toggles the image between total intensity and intensity-weighted mean Doppler velocity.
- Display normalizations are global and data-derived at construction (intensity, Doppler, and slit norms are fixed over the whole cube; the spectrum panel's y-limit is the per-point maximum over time), so browsing does not rescale under the cursor.
- Colorbars are attached to explicit axes, with clipping shown via extend arrows.
- Axis labels are built from the logical axis names and coordinate units of the input `FunctionArray`.

## Testing

16 new tests (run under `MPLBACKEND=Agg`) covering construction, norm derivation, event handling, and label generation, alongside the existing suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)