### PR TITLE
Inherit `TemporalDopplerPositionalVectorArray` from `DopplerPositionalVectorArray`

### DIFF
--- a/named_arrays/_vectors/vectors_temporal_doppler_positonal.py
+++ b/named_arrays/_vectors/vectors_temporal_doppler_positonal.py
@@ -17,8 +17,7 @@ WavelengthT = TypeVar("WavelengthT", bound=na.ScalarLike)
 
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractTemporalDopplerPositionalVectorArray(
-    na.AbstractPositionalVectorArray,
-    na.AbstractDopplerVectorArray,
+    na.AbstractDopplerPositionalVectorArray,
     na.AbstractTemporalVectorArray,
 ):
 
@@ -38,8 +37,7 @@ class AbstractTemporalDopplerPositionalVectorArray(
 @dataclasses.dataclass(eq=False, repr=False)
 class TemporalDopplerPositionalVectorArray(
     AbstractTemporalDopplerPositionalVectorArray,
-    na.PositionalVectorArray[PositionT],
-    na.DopplerVectorArray[WavelengthT],
+    na.DopplerPositionalVectorArray[PositionT, WavelengthT],
     na.TemporalVectorArray[TimeT]
 ):
     pass
@@ -48,8 +46,7 @@ class TemporalDopplerPositionalVectorArray(
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractImplicitTemporalDopplerPositionalVectorArray(
     AbstractTemporalDopplerPositionalVectorArray,
-    na.AbstractImplicitPositionalVectorArray,
-    na.AbstractImplicitDopplerVectorArray,
+    na.AbstractImplicitDopplerPositionalVectorArray,
     na.AbstractImplicitTemporalVectorArray,
 ):
     pass


### PR DESCRIPTION
`TemporalDopplerPositionalVectorArray` previously inherited separately from `PositionalVectorArray` and `DopplerVectorArray`, so it was not a subclass of `DopplerPositionalVectorArray` and could not be passed where a doppler-positional vector was expected.

This rebases all three variants on their doppler-positional counterparts:

| class | old bases | new bases |
| --- | --- | --- |
| `AbstractTemporalDopplerPositionalVectorArray` | `AbstractPositionalVectorArray`, `AbstractDopplerVectorArray`, `AbstractTemporalVectorArray` | `AbstractDopplerPositionalVectorArray`, `AbstractTemporalVectorArray` |
| `TemporalDopplerPositionalVectorArray` | `PositionalVectorArray[PositionT]`, `DopplerVectorArray[WavelengthT]`, `TemporalVectorArray[TimeT]` | `DopplerPositionalVectorArray[PositionT, WavelengthT]`, `TemporalVectorArray[TimeT]` |
| `AbstractImplicitTemporalDopplerPositionalVectorArray` | `AbstractImplicitPositionalVectorArray`, `AbstractImplicitDopplerVectorArray`, `AbstractImplicitTemporalVectorArray` | `AbstractImplicitDopplerPositionalVectorArray`, `AbstractImplicitTemporalVectorArray` |

Notes:

- Dataclass field order is unchanged (`time`, `wavelength`, `wavelength_rest`, `position`) for both `TemporalDopplerPositionalVectorArray` and `TemporalDopplerPositionalMatrixArray`, verified against the pre-change tree, so positional construction is unaffected.
- The MRO still reaches `PositionalVectorArray`, `DopplerVectorArray`, and `TemporalVectorArray` in the same relative order.
- The class now inherits the `spectral_positional` property added in #196, which returns a `SpectralPositionalVectorArray` and therefore drops `time` along with `wavelength_rest`. This is new behavior for this type.

Tests: the temporal-doppler-positional, doppler-positional, and full matrix suites pass (2727 passed, 68 skipped, 2 xfailed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxPvzyjxGLZbhy9YKH3f88
